### PR TITLE
ci: generate versioned tags

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -2,34 +2,50 @@ name: Build and Push Image to Dockerhub and GHCR
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
+  release:
+    types: ["published"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Login to DockerHub
-      uses: docker/login-action@v3
-      with:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
           username: "${{ secrets.DH_USER }}"
           password: "${{ secrets.DH_PASS }}"
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
           registry: ghcr.io
           username: "hargata"
           password: "${{ secrets.GHCR_PAT }}"
-    - name: Build and push
-      uses: docker/build-push-action@v5
-      with:
+
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          context: workflow
+          images: |
+            hargata/lubelogger
+            ghcr.io/hargata/lubelogger
+          tags: |
+            type=edge,branch=main
+            type=ref,event=tag
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            hargata/lubelogger:latest
-            ghcr.io/hargata/lubelogger:latest
-              
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Based on Issue #226 

Generates an image tag based on release tag, as well as generating a `latest` tag. Also generates an `edge` tag for the latest pushes to the main branch. The primary changes are in lines 31-46, and 50-51. The other insertions/deletions were my VS Code setup which auto-formats the YAML. I also added `labels` based on the action example but I'm not sure it's necessary.

I was unable to test pushing the image, but the metadata step when sent to the build step created these tags based on my inputting the release name 1.1.1.5: 
- hargata/lubelogger:1.1.1.5 
- hargata/lubelogger:latest 
- ghcr.io/hargata/lubelogger:1.1.1.5
- ghcr.io/hargata/lubelogger:latest