### PR TITLE
Changed OAuth Login username to use "nickname" from oauth vice "email address"

### DIFF
--- a/Controllers/LoginController.cs
+++ b/Controllers/LoginController.cs
@@ -99,6 +99,11 @@ namespace CarCareTracker.Controllers
                         var tokenParser = new JwtSecurityTokenHandler();
                         var parsedToken = tokenParser.ReadJwtToken(userJwt);
                         var userEmailAddress = parsedToken.Claims.First(x => x.Type == "email").Value;
+                        var userNickName = parsedToken.Claims.First(x => x.Type == "nickname").Value;
+                        UserData data = new UserData(){
+                            UserName = userNickName,
+                            EmailAddress = userEmailAddress
+                        };
                         if (!string.IsNullOrWhiteSpace(userEmailAddress))
                         {
                             var userData = _loginLogic.ValidateOpenIDUser(new LoginModel() { EmailAddress = userEmailAddress });
@@ -116,7 +121,7 @@ namespace CarCareTracker.Controllers
                             } else
                             {
                                 _logger.LogInformation($"User {userEmailAddress} tried to login via OpenID but is not a registered user in LubeLogger.");
-                                return View("OpenIDRegistration", model: userEmailAddress);
+                                return View("OpenIDRegistration", model: data);
                             }
                         }
                     }

--- a/Views/Login/OpenIDRegistration.cshtml
+++ b/Views/Login/OpenIDRegistration.cshtml
@@ -5,7 +5,7 @@
     var logoUrl = config.GetLogoUrl();
     var userLanguage = config.GetServerLanguage();
 }
-@model string
+@model UserData
 @{
     ViewData["Title"] = "LubeLogger - Register";
 }
@@ -22,7 +22,7 @@
             </div>
             <div class="form-group">
                 <label for="inputUserName">@translator.Translate(userLanguage, "Username")</label>
-                <input type="text" id="inputUserName" class="form-control" value="@Model">
+                <input type="text" id="inputUserName" class="form-control" value="@Model.UserName">
             </div>
             <div class="d-grid">
                 <button type="button" class="btn btn-warning mt-2" onclick="performOpenIdRegistration()"><i class="bi bi-box-arrow-in-right me-2"></i>@translator.Translate(userLanguage, "Register")</button>
@@ -37,7 +37,7 @@
     function performOpenIdRegistration() {
         var token = $("#inputToken").val();
         var userName = $("#inputUserName").val();
-        var userEmail = decodeHTMLEntities('@Model');
+        var userEmail = decodeHTMLEntities('@Model.EmailAddress');
         $.post('/Login/RegisterOpenIdUser', { userName: userName, token: token, emailAddress: userEmail }, function (data) {
             if (data.success) {
                 successToast(data.message);

--- a/appsettings.json
+++ b/appsettings.json
@@ -24,5 +24,15 @@
   "VisibleTabs": [ 0, 1, 4, 2, 3, 6, 5, 8 ],
   "DefaultTab": 8,
   "UserNameHash": "",
-  "UserPasswordHash": ""
+  "UserPasswordHash": "",
+  "OpenIDConfig": {
+    "Name": "LocalNonsense",
+    "ClientId": "client1",
+    "ClientSecret": "secret",
+    "AuthURL": "http://10.10.81.70:8090/issuer1/authorize",
+    "TokenURL": "http://10.10.81.70:8090/issuer1/token",
+    "RedirectURL": "https://localhost:5001/Login/RemoteAuth",
+    "Scope": "openid",
+    "ValidateState": false
+  }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -24,15 +24,5 @@
   "VisibleTabs": [ 0, 1, 4, 2, 3, 6, 5, 8 ],
   "DefaultTab": 8,
   "UserNameHash": "",
-  "UserPasswordHash": "",
-  "OpenIDConfig": {
-    "Name": "LocalNonsense",
-    "ClientId": "client1",
-    "ClientSecret": "secret",
-    "AuthURL": "http://10.10.81.70:8090/issuer1/authorize",
-    "TokenURL": "http://10.10.81.70:8090/issuer1/token",
-    "RedirectURL": "https://localhost:5001/Login/RemoteAuth",
-    "Scope": "openid",
-    "ValidateState": false
-  }
+  "UserPasswordHash": ""
 }


### PR DESCRIPTION
When logging in via Oauth, I noticed your username would be forced as your email address and therefore show in the top right as your user. Given that regular users have a username, I found it necessary for oauth to do the same. 