### PR TITLE
Allow users to bring back modal window they accidentally closed.

### DIFF
--- a/wwwroot/js/shared.js
+++ b/wwwroot/js/shared.js
@@ -706,9 +706,56 @@ $(window).on('keydown', function (e) {
             e.preventDefault();
             e.stopPropagation();
             selectAllRows();
+        } else if ((e.ctrlKey || e.metaKey) && e.which == 90) {
+            e.preventDefault();
+            e.stopPropagation();
+            showModalForCurrentTab();
         }
     }
-})
+});
+function getCurrentTab() {
+    return $(".tab-pane.active.show").attr('id');
+}
+function showModalForCurrentTab() {
+    var currentTab = getCurrentTab();
+    var modalName = "";
+    switch (currentTab) {
+        case "servicerecord-tab-pane":
+            modalName = "serviceRecordModal";
+            break;
+        case "gas-tab-pane":
+            modalName = "gasRecordModal";
+            break;
+        case "tax-tab-pane":
+            modalName = "taxRecordModal";
+            break;
+        case "notes-tab-pane":
+            modalName = "noteModal";
+            break;
+        case "accident-tab-pane":
+            modalName = "collisionRecordModal";
+            break;
+        case "upgrade-tab-pane":
+            modalName = "upgradeRecordModal";
+            break;
+        case "supply-tab-pane":
+            modalName = "supplyRecordModal";
+            break;
+        case "plan-tab-pane":
+            modalName = "planRecordModal";
+            break;
+        case "odometer-tab-pane":
+            modalName = "odometerRecordModal";
+            break;
+    }
+    if (modalName != '') {
+        //check if modal has content and no other modal is currently showing.
+        var modalContent = $(`#${modalName} .modal-content`);
+        if (modalContent.html().trim() != '' && $(".modal.fade.show").length == 0) {
+            $(`#${modalName}`).modal('show');
+        }
+    }
+}
 function selectAllRows() {
     clearSelectedRows();
     $('.vehicleDetailTabContainer .table tbody tr:visible').addClass('table-active');


### PR DESCRIPTION
If the user is in the middle of entering a record and they accidentally closed the window either by clicking on "X", "Cancel", ESC key, or clicking anywhere outside the modal and they have unsaved changes, they can bring back the modal with those changes using the CTRL+Z key. This "draft" mode will persist until the user switches to a different tab or if they save / delete / move the record.