### PR TITLE
Add Default Reminder Email Recipient

### DIFF
--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -700,17 +700,17 @@ namespace CarCareTracker.Controllers
             }
             if (!operationResponses.Any())
             {
-                return Json(new OperationResponse { Success = false, Message = "No Emails sent either because there are no vehicles or no recipients" });
+                return Json(new OperationResponse { Success = false, Message = "No Emails Sent, No Vehicles Available or No Recipients Configured" });
             }
             else if (operationResponses.All(x => x.Success))
             {
-                return Json(new OperationResponse { Success = true, Message = $"{operationResponses.Count()} Emails sent" });
+                return Json(new OperationResponse { Success = true, Message = $"Emails Sent({operationResponses.Count()})" });
             } else if (operationResponses.All(x => !x.Success))
             {
-                return Json(new OperationResponse { Success = false, Message = "All emails failed, check SMTP settings" });
+                return Json(new OperationResponse { Success = false, Message = $"All Emails Failed({operationResponses.Count()}), Check SMTP Settings" });
             } else
             {
-                return Json(new OperationResponse { Success = true, Message = $"{operationResponses.Count(x=>x.Success)} Emails sent, {operationResponses.Count(x => !x.Success)} failed, check recipient settings" });
+                return Json(new OperationResponse { Success = true, Message = $"Emails Sent({operationResponses.Count(x => x.Success)}), Emails Failed({operationResponses.Count(x => !x.Success)}), Check Recipient Settings" });
             }
         }
         [Authorize(Roles = nameof(UserData.IsRootUser))]

--- a/Helper/ConfigHelper.cs
+++ b/Helper/ConfigHelper.cs
@@ -14,6 +14,7 @@ namespace CarCareTracker.Helper
         bool AuthenticateRootUser(string username, string password);
         string GetWebHookUrl();
         string GetMOTD();
+        string GetDefaultReminderEmail();
         string GetLogoUrl();
         string GetServerLanguage();
         bool GetServerEnableShopSupplies();
@@ -51,6 +52,15 @@ namespace CarCareTracker.Helper
                 motd = "";
             }
             return motd;
+        }
+        public string GetDefaultReminderEmail()
+        {
+            var defaultEmail = _config["DEFAULT_REMINDER_EMAIL"];
+            if (string.IsNullOrWhiteSpace(defaultEmail))
+            {
+                defaultEmail = "";
+            }
+            return defaultEmail;
         }
         public OpenIDConfig GetOpenIDConfig()
         {

--- a/Helper/MailHelper.cs
+++ b/Helper/MailHelper.cs
@@ -113,14 +113,20 @@ namespace CarCareTracker.Helper
             string tableBody = "";
             foreach(ReminderRecordViewModel reminder in reminders)
             {
-                var dueOn = reminder.Metric == ReminderMetric.Both ? $"{reminder.Date} or {reminder.Mileage}" : reminder.Metric == ReminderMetric.Date ? $"{reminder.Date.ToShortDateString()}" : $"{reminder.Mileage}";
+                var dueOn = reminder.Metric == ReminderMetric.Both ? $"{reminder.Date.ToShortDateString()} or {reminder.Mileage}" : reminder.Metric == ReminderMetric.Date ? $"{reminder.Date.ToShortDateString()}" : $"{reminder.Mileage}";
                 tableBody += $"<tr class='{reminder.Urgency}'><td>{StaticHelper.GetTitleCaseReminderUrgency(reminder.Urgency)}</td><td>{reminder.Description}</td><td>{dueOn}</td></tr>";
             }
             emailBody = emailBody.Replace("{TableBody}", tableBody);
             try
             {
-                SendEmail(emailAddresses, emailSubject, emailBody);
-                return new OperationResponse { Success = true, Message = "Email Sent!" };
+                var result = SendEmail(emailAddresses, emailSubject, emailBody);
+                if (result)
+                {
+                    return new OperationResponse { Success = true, Message = "Email Sent!" };
+                } else
+                {
+                    return new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage };
+                }
             } catch (Exception ex)
             {
                 return new OperationResponse { Success = false, Message = ex.Message };


### PR DESCRIPTION
Users will now have the ability to configure a default email recipient for reminder emails, useful if they're the root user and don't wish to create another user just to be able to receive emails.

Also fixed some bugs and improved the error messages associated with failed emails.

See #517 