### PR TITLE
Fixed minor bug with translation editor.

### DIFF
--- a/Helper/TranslationHelper.cs
+++ b/Helper/TranslationHelper.cs
@@ -146,7 +146,7 @@ namespace CarCareTracker.Helper
                 } else
                 {
                     //check if directory exists first.
-                    var translationDirectory = _fileHelper.GetFullFilePath("/translations/", false);
+                    var translationDirectory = _fileHelper.GetFullFilePath("translations/", false);
                     if (!Directory.Exists(translationDirectory))
                     {
                         Directory.CreateDirectory(translationDirectory);

--- a/Helper/TranslationHelper.cs
+++ b/Helper/TranslationHelper.cs
@@ -145,6 +145,12 @@ namespace CarCareTracker.Helper
                     _cache.Remove($"lang_{userLanguage}"); //clear out cache, force a reload from file.
                 } else
                 {
+                    //check if directory exists first.
+                    var translationDirectory = _fileHelper.GetFullFilePath("/translations/", false);
+                    if (!Directory.Exists(translationDirectory))
+                    {
+                        Directory.CreateDirectory(translationDirectory);
+                    }
                     //write to file
                     File.WriteAllText(translationFilePath, JsonSerializer.Serialize(translations));
                 }


### PR DESCRIPTION
This is a very minor bug with workarounds, primarily, if you've never had a translation file uploaded to LubeLogger, you will get an error when you try to download any translations via the Translation Getter or make any edits using the Translation Editor.

The workaround is as follows:
Create a `.json` file and upload it as a translation. This will create the translation folder that will allow you to then download or edit translations. You can then freely delete that json file afterwards.