### PR TITLE
#2 Code clean up

### DIFF
--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -34,6 +34,9 @@ namespace CarCareTracker.Controllers
         private readonly IFileHelper _fileHelper;
         private readonly IMailHelper _mailHelper;
         private readonly IConfigHelper _config;
+
+        private const string InputObjectInvalidDateDescriptionOdometerCost = "Input object invalid, Date, Description, Odometer, and Cost cannot be empty.";
+        
         public APIController(IVehicleDataAccess dataAccess,
             IGasHelper gasHelper,
             IReminderHelper reminderHelper,
@@ -150,11 +153,8 @@ namespace CarCareTracker.Controllers
         {
             if (vehicleId == default)
             {
-                var response = new OperationResponse();
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             var vehicleRecords = _serviceRecordDataAccess.GetServiceRecordsByVehicleId(vehicleId);
             var result = vehicleRecords.Select(x => new GenericRecordExportModel { Date = x.Date.ToShortDateString(), Description = x.Description, Cost = x.Cost.ToString(), Notes = x.Notes, Odometer = x.Mileage.ToString(), ExtraFields = x.ExtraFields });
@@ -165,23 +165,18 @@ namespace CarCareTracker.Controllers
         [Route("/api/vehicle/servicerecords/add")]
         public IActionResult AddServiceRecord(int vehicleId, GenericRecordExportModel input)
         {
-            var response = new OperationResponse();
             if (vehicleId == default)
             {
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             if (string.IsNullOrWhiteSpace(input.Date) ||
                 string.IsNullOrWhiteSpace(input.Description) ||
                 string.IsNullOrWhiteSpace(input.Odometer) ||
                 string.IsNullOrWhiteSpace(input.Cost))
             {
-                response.Success = false;
-                response.Message = "Input object invalid, Date, Description, Odometer, and Cost cannot be empty.";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(false, InputObjectInvalidDateDescriptionOdometerCost));
             }
             try
             {
@@ -209,16 +204,12 @@ namespace CarCareTracker.Controllers
                     _odometerLogic.AutoInsertOdometerRecord(odometerRecord);
                 }
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), vehicleId, User.Identity.Name, $"Added Service Record via API - Description: {serviceRecord.Description}");
-                response.Success = true;
-                response.Message = "Service Record Added";
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(true, "Service Record Added"));
             }
             catch (Exception ex)
             {
-                response.Success = false;
-                response.Message = ex.Message;
                 Response.StatusCode = 500;
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(false, ex.Message));
             }
         }
         [TypeFilter(typeof(CollaboratorFilter))]
@@ -228,11 +219,8 @@ namespace CarCareTracker.Controllers
         {
             if (vehicleId == default)
             {
-                var response = new OperationResponse();
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             var vehicleRecords = _collisionRecordDataAccess.GetCollisionRecordsByVehicleId(vehicleId);
             var result = vehicleRecords.Select(x => new GenericRecordExportModel { Date = x.Date.ToShortDateString(), Description = x.Description, Cost = x.Cost.ToString(), Notes = x.Notes, Odometer = x.Mileage.ToString(), ExtraFields = x.ExtraFields });
@@ -243,23 +231,18 @@ namespace CarCareTracker.Controllers
         [Route("/api/vehicle/repairrecords/add")]
         public IActionResult AddRepairRecord(int vehicleId, GenericRecordExportModel input)
         {
-            var response = new OperationResponse();
             if (vehicleId == default)
             {
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             if (string.IsNullOrWhiteSpace(input.Date) ||
                 string.IsNullOrWhiteSpace(input.Description) ||
                 string.IsNullOrWhiteSpace(input.Odometer) ||
                 string.IsNullOrWhiteSpace(input.Cost))
             {
-                response.Success = false;
-                response.Message = "Input object invalid, Date, Description, Odometer, and Cost cannot be empty.";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(false, InputObjectInvalidDateDescriptionOdometerCost));
             }
             try
             {
@@ -287,16 +270,12 @@ namespace CarCareTracker.Controllers
                     _odometerLogic.AutoInsertOdometerRecord(odometerRecord);
                 }
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), vehicleId, User.Identity.Name, $"Added Repair Record via API - Description: {repairRecord.Description}");
-                response.Success = true;
-                response.Message = "Repair Record Added";
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(true, "Repair Record Added"));
             }
             catch (Exception ex)
             {
-                response.Success = false;
-                response.Message = ex.Message;
                 Response.StatusCode = 500;
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(false, ex.Message));
             }
         }
         [TypeFilter(typeof(CollaboratorFilter))]
@@ -306,11 +285,8 @@ namespace CarCareTracker.Controllers
         {
             if (vehicleId == default)
             {
-                var response = new OperationResponse();
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             var vehicleRecords = _upgradeRecordDataAccess.GetUpgradeRecordsByVehicleId(vehicleId);
             var result = vehicleRecords.Select(x => new GenericRecordExportModel { Date = x.Date.ToShortDateString(), Description = x.Description, Cost = x.Cost.ToString(), Notes = x.Notes, Odometer = x.Mileage.ToString(), ExtraFields = x.ExtraFields });
@@ -321,23 +297,18 @@ namespace CarCareTracker.Controllers
         [Route("/api/vehicle/upgraderecords/add")]
         public IActionResult AddUpgradeRecord(int vehicleId, GenericRecordExportModel input)
         {
-            var response = new OperationResponse();
             if (vehicleId == default)
             {
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             if (string.IsNullOrWhiteSpace(input.Date) ||
                 string.IsNullOrWhiteSpace(input.Description) ||
                 string.IsNullOrWhiteSpace(input.Odometer) ||
                 string.IsNullOrWhiteSpace(input.Cost))
             {
-                response.Success = false;
-                response.Message = "Input object invalid, Date, Description, Odometer, and Cost cannot be empty.";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(false, InputObjectInvalidDateDescriptionOdometerCost));
             }
             try
             {
@@ -365,16 +336,12 @@ namespace CarCareTracker.Controllers
                     _odometerLogic.AutoInsertOdometerRecord(odometerRecord);
                 }
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), vehicleId, User.Identity.Name, $"Added Upgrade Record via API - Description: {upgradeRecord.Description}");
-                response.Success = true;
-                response.Message = "Upgrade Record Added";
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(true, "Upgrade Record Added"));
             }
             catch (Exception ex)
             {
-                response.Success = false;
-                response.Message = ex.Message;
                 Response.StatusCode = 500;
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(false, ex.Message));
             }
         }
         [TypeFilter(typeof(CollaboratorFilter))]
@@ -384,11 +351,8 @@ namespace CarCareTracker.Controllers
         {
             if (vehicleId == default)
             {
-                var response = new OperationResponse();
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             var result = _taxRecordDataAccess.GetTaxRecordsByVehicleId(vehicleId).Select(x => new TaxRecordExportModel { Date = x.Date.ToShortDateString(), Description = x.Description, Cost = x.Cost.ToString(), Notes = x.Notes, ExtraFields = x.ExtraFields });
             return Json(result);
@@ -448,11 +412,8 @@ namespace CarCareTracker.Controllers
         {
             if (vehicleId == default)
             {
-                var response = new OperationResponse();
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             var result = _vehicleLogic.GetMaxMileage(vehicleId);
             return Json(result);
@@ -464,11 +425,8 @@ namespace CarCareTracker.Controllers
         {
             if (vehicleId == default)
             {
-                var response = new OperationResponse();
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             var vehicleRecords = _odometerRecordDataAccess.GetOdometerRecordsByVehicleId(vehicleId);
             //determine if conversion is needed.
@@ -484,21 +442,16 @@ namespace CarCareTracker.Controllers
         [Route("/api/vehicle/odometerrecords/add")]
         public IActionResult AddOdometerRecord(int vehicleId, OdometerRecordExportModel input)
         {
-            var response = new OperationResponse();
             if (vehicleId == default)
             {
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             if (string.IsNullOrWhiteSpace(input.Date) ||
                 string.IsNullOrWhiteSpace(input.Odometer))
             {
-                response.Success = false;
-                response.Message = "Input object invalid, Date and Odometer cannot be empty.";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(false, "Input object invalid, Date and Odometer cannot be empty."));
             }
             try
             {
@@ -514,15 +467,11 @@ namespace CarCareTracker.Controllers
                 };
                 _odometerRecordDataAccess.SaveOdometerRecordToVehicle(odometerRecord);
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), vehicleId, User.Identity.Name, $"Added Odometer Record via API - Mileage: {odometerRecord.Mileage.ToString()}");
-                response.Success = true;
-                response.Message = "Odometer Record Added";
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(true, "Odometer Record Added"));
             } catch (Exception ex)
             {
-                response.Success = false;
-                response.Message = ex.Message;
                 Response.StatusCode = 500;
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(false, ex.Message));
             }
         }
         [TypeFilter(typeof(CollaboratorFilter))]
@@ -532,11 +481,8 @@ namespace CarCareTracker.Controllers
         {
             if (vehicleId == default)
             {
-                var response = new OperationResponse();
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             var vehicleRecords = _gasRecordDataAccess.GetGasRecordsByVehicleId(vehicleId);
             var result = _gasHelper.GetGasRecordViewModels(vehicleRecords, useMPG, useUKMPG)
@@ -558,13 +504,10 @@ namespace CarCareTracker.Controllers
         [Route("/api/vehicle/gasrecords/add")]
         public IActionResult AddGasRecord(int vehicleId, GasRecordExportModel input)
         {
-            var response = new OperationResponse();
             if (vehicleId == default)
             {
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             if (string.IsNullOrWhiteSpace(input.Date) ||
                 string.IsNullOrWhiteSpace(input.Odometer) ||
@@ -574,10 +517,8 @@ namespace CarCareTracker.Controllers
                 string.IsNullOrWhiteSpace(input.MissedFuelUp)
                 )
             {
-                response.Success = false;
-                response.Message = "Input object invalid, Date, Odometer, FuelConsumed, IsFillToFull, MissedFuelUp, and Cost cannot be empty.";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(false, "Input object invalid, Date, Odometer, FuelConsumed, IsFillToFull, MissedFuelUp, and Cost cannot be empty."));
             }
             try
             {
@@ -607,16 +548,12 @@ namespace CarCareTracker.Controllers
                     _odometerLogic.AutoInsertOdometerRecord(odometerRecord);
                 }
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), vehicleId, User.Identity.Name, $"Added Gas record via API - Mileage: {gasRecord.Mileage.ToString()}");
-                response.Success = true;
-                response.Message = "Gas Record Added";
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(true, "Gas Record Added"));
             }
             catch (Exception ex)
             {
-                response.Success = false;
-                response.Message = ex.Message;
                 Response.StatusCode = 500;
-                return Json(response);
+                return Json(StaticHelper.GetOperationResponse(false, ex.Message));
             }
         }
         [TypeFilter(typeof(CollaboratorFilter))]
@@ -626,11 +563,8 @@ namespace CarCareTracker.Controllers
         {
             if (vehicleId == default)
             {
-                var response = new OperationResponse();
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
                 Response.StatusCode = 400;
-                return Json(response);
+                return Json(GetInvalidVehicleIdOperationResponse());
             }
             var currentMileage = _vehicleLogic.GetMaxMileage(vehicleId);
             var reminders = _reminderRecordDataAccess.GetReminderRecordsByVehicleId(vehicleId);
@@ -678,17 +612,18 @@ namespace CarCareTracker.Controllers
             }
             if (!operationResponses.Any())
             {
-                return Json(new OperationResponse { Success = false, Message = "No Emails Sent, No Vehicles Available or No Recipients Configured" });
+                return Json(StaticHelper.GetOperationResponse(false, "No Emails Sent, No Vehicles Available or No Recipients Configured"));
             }
             else if (operationResponses.All(x => x.Success))
             {
-                return Json(new OperationResponse { Success = true, Message = $"Emails Sent({operationResponses.Count()})" });
+                return Json(StaticHelper.GetOperationResponse(true, $"Emails Sent({operationResponses.Count})"));
             } else if (operationResponses.All(x => !x.Success))
             {
-                return Json(new OperationResponse { Success = false, Message = $"All Emails Failed({operationResponses.Count()}), Check SMTP Settings" });
+                return Json(StaticHelper.GetOperationResponse(false, $"All Emails Failed({operationResponses.Count}), Check SMTP Settings"));
             } else
             {
-                return Json(new OperationResponse { Success = true, Message = $"Emails Sent({operationResponses.Count(x => x.Success)}), Emails Failed({operationResponses.Count(x => !x.Success)}), Check Recipient Settings" });
+                return Json(StaticHelper.GetOperationResponse(true, 
+                $"Emails Sent({operationResponses.Count(x => x.Success)}), Emails Failed({operationResponses.Count(x => !x.Success)}), Check Recipient Settings"));
             }
         }
         [Authorize(Roles = nameof(UserData.IsRootUser))]
@@ -749,6 +684,11 @@ namespace CarCareTracker.Controllers
         {
             var result = _fileHelper.RestoreBackup("/defaults/demo_default.zip", true);
             return Json(result);
+        }
+
+        private static OperationResponse GetInvalidVehicleIdOperationResponse()
+        {
+            return StaticHelper.GetOperationResponse(false, "Must provide a valid vehicle id");
         }
     }
 }

--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -362,11 +362,11 @@ namespace CarCareTracker.Controllers
         [Route("/api/vehicle/taxrecords/add")]
         public IActionResult AddTaxRecord(int vehicleId, TaxRecordExportModel input)
         {
-            var response = new OperationResponse();
+            OperationResponse response;
+            
             if (vehicleId == default)
             {
-                response.Success = false;
-                response.Message = "Must provide a valid vehicle id";
+                response = GetInvalidVehicleIdOperationResponse();
                 Response.StatusCode = 400;
                 return Json(response);
             }
@@ -374,8 +374,7 @@ namespace CarCareTracker.Controllers
                 string.IsNullOrWhiteSpace(input.Description) ||
                 string.IsNullOrWhiteSpace(input.Cost))
             {
-                response.Success = false;
-                response.Message = "Input object invalid, Date, Description, and Cost cannot be empty.";
+                response = StaticHelper.GetOperationResponse(false, "Input object invalid, Date, Description, and Cost cannot be empty.");
                 Response.StatusCode = 400;
                 return Json(response);
             }
@@ -393,14 +392,12 @@ namespace CarCareTracker.Controllers
                 };
                 _taxRecordDataAccess.SaveTaxRecordToVehicle(taxRecord);
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), vehicleId, User.Identity.Name, $"Added Tax Record via API - Description: {taxRecord.Description}");
-                response.Success = true;
-                response.Message = "Tax Record Added";
+                response = StaticHelper.GetOperationResponse(true, "Tax Record Added");
                 return Json(response);
             }
             catch (Exception ex)
             {
-                response.Success = false;
-                response.Message = ex.Message;
+                response = StaticHelper.GetOperationResponse(false, ex.Message);
                 Response.StatusCode = 500;
                 return Json(response);
             }

--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -55,8 +55,7 @@ namespace CarCareTracker.Controllers
                         }
                     }
                 }
-                var successResponse = new OperationResponse { Success = true, Message = "Token Generated!" };
-                return Json(successResponse);
+                return Json(StaticHelper.GetOperationResponse(true, "Token Generated!"));
             } else
             {
                 var result = _loginLogic.GenerateUserToken(emailAddress, autoNotify);

--- a/Controllers/FilesController.cs
+++ b/Controllers/FilesController.cs
@@ -32,7 +32,7 @@ namespace CarCareTracker.Controllers
             var originalFileName = Path.GetFileNameWithoutExtension(file.FileName);
             if (originalFileName == "en_US")
             {
-                return Json(new OperationResponse { Success = false, Message = "The translation file name en_US is reserved." });
+                return Json(StaticHelper.GetOperationResponse(false, "The translation file name en_US is reserved."));
             }
             var fileName = UploadFile(file);
             //move file from temp to translation folder.
@@ -41,9 +41,9 @@ namespace CarCareTracker.Controllers
             if (!string.IsNullOrWhiteSpace(uploadedFilePath))
             {
                 var result = _fileHelper.RenameFile(uploadedFilePath, originalFileName);
-                return Json(new OperationResponse { Success = result, Message = string.Empty });
+                return Json(StaticHelper.GetOperationResponse(result, string.Empty));
             }
-            return Json(new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage });
+            return Json(StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage));
         }
 
         [HttpPost]

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -280,12 +280,12 @@ namespace CarCareTracker.Controllers
                     var result = _loginLogic.UpdateUserDetails(userId, userAccount);
                     return Json(result);
                 }
-                return Json(new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage });
+                return Json(StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage));
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex.Message);
-                return Json(new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage });
+                return Json(StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage));
             }
         }
         [HttpGet]
@@ -493,16 +493,16 @@ namespace CarCareTracker.Controllers
                 }
                 if (translationsDownloaded > 0)
                 {
-                    return Json(new OperationResponse() { Success = true, Message = $"{translationsDownloaded} Translations Downloaded" });
+                    return Json(StaticHelper.GetOperationResponse(true, $"{translationsDownloaded} Translations Downloaded"));
                 } else
                 {
-                    return Json(new OperationResponse() { Success = false, Message = "No Translations Downloaded" });
+                    return Json(StaticHelper.GetOperationResponse(false, "No Translations Downloaded"));
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogError($"Unable to retrieve translations: {ex.Message}");
-                return Json(new OperationResponse() { Success = false, Message = StaticHelper.GenericErrorMessage });
+                return Json(StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage));
             }
         }
         public ActionResult GetVehicleSelector(int vehicleId)

--- a/Controllers/MigrationController.cs
+++ b/Controllers/MigrationController.cs
@@ -66,7 +66,7 @@ namespace CarCareTracker.Controllers
         {
             if (string.IsNullOrWhiteSpace(_configHelper.GetServerPostgresConnection()))
             {
-                return Json(new OperationResponse { Success = false, Message = "Postgres connection not set up" });
+                return Json(StaticHelper.GetOperationResponse(false, "Postgres connection not set up"));
             }
             var tempFolder = $"temp/{Guid.NewGuid()}";
             var tempPath = $"{tempFolder}/cartracker.db";
@@ -419,24 +419,24 @@ namespace CarCareTracker.Controllers
                 #endregion
                 var destFilePath = $"{fullFolderPath}.zip";
                 ZipFile.CreateFromDirectory(fullFolderPath, destFilePath);
-                return Json(new OperationResponse { Success = true, Message = $"/{tempFolder}.zip" });
+                return Json(StaticHelper.GetOperationResponse(true, $"/{tempFolder}.zip"));
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex.Message);
-                return Json(new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage });
+                return Json(StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage));
             }
         }
         public IActionResult Import(string fileName)
         {
             if (string.IsNullOrWhiteSpace(_configHelper.GetServerPostgresConnection()))
             {
-                return Json(new OperationResponse { Success = false, Message = "Postgres connection not set up" });
+                return Json(StaticHelper.GetOperationResponse(false, "Postgres connection not set up"));
             }
             var fullFileName = _fileHelper.GetFullFilePath(fileName);
             if (string.IsNullOrWhiteSpace(fullFileName))
             {
-                return Json(new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage });
+                return Json(StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage));
             }
             try
             {
@@ -744,12 +744,12 @@ namespace CarCareTracker.Controllers
                     }
                 }
                 #endregion
-                return Json(new OperationResponse { Success = true, Message = "Data Imported Successfully" });
+                return Json(StaticHelper.GetOperationResponse(true, "Data Imported Successfully"));
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex.Message);
-                return Json(new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage });
+                return Json(StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage));
             }
         }
     }

--- a/Controllers/Vehicle/PlanController.cs
+++ b/Controllers/Vehicle/PlanController.cs
@@ -47,11 +47,11 @@ namespace CarCareTracker.Controllers
             var existingRecord = _planRecordTemplateDataAccess.GetPlanRecordTemplatesByVehicleId(planRecord.VehicleId).Where(x => x.Description == planRecord.Description).Any();
             if (planRecord.Id == default && existingRecord)
             {
-                return Json(new OperationResponse { Success = false, Message = "A template with that description already exists for this vehicle" });
+                return Json(StaticHelper.GetOperationResponse(false, "A template with that description already exists for this vehicle"));
             }
             planRecord.Files = planRecord.Files.Select(x => { return new UploadedFiles { Name = x.Name, Location = _fileHelper.MoveFileFromTemp(x.Location, "documents/") }; }).ToList();
             var result = _planRecordTemplateDataAccess.SavePlanRecordTemplateToVehicle(planRecord);
-            return Json(new OperationResponse { Success = result, Message = result ? "Template Added" : StaticHelper.GenericErrorMessage });
+            return Json(StaticHelper.GetOperationResponse(result, result ? "Template Added" : StaticHelper.GenericErrorMessage));
         }
         [TypeFilter(typeof(CollaboratorFilter))]
         [HttpGet]
@@ -72,7 +72,7 @@ namespace CarCareTracker.Controllers
             var existingRecord = _planRecordTemplateDataAccess.GetPlanRecordTemplateById(planRecordTemplateId);
             if (existingRecord.Id == default)
             {
-                return Json(new OperationResponse { Success = false, Message = "Unable to find template" });
+                return Json(StaticHelper.GetOperationResponse(false, "Unable to find template"));
             }
             if (existingRecord.Supplies.Any())
             {
@@ -81,7 +81,7 @@ namespace CarCareTracker.Controllers
             } 
             else
             {
-                return Json(new OperationResponse { Success = false, Message = "Template has No Supplies" });
+                return Json(StaticHelper.GetOperationResponse(false, "Template has No Supplies"));
             }
         }
         [HttpPost]
@@ -90,7 +90,7 @@ namespace CarCareTracker.Controllers
             var existingRecord = _planRecordTemplateDataAccess.GetPlanRecordTemplateById(planRecordTemplateId);
             if (existingRecord.Id == default)
             {
-                return Json(new OperationResponse { Success = false, Message = "Unable to find template" });
+                return Json(StaticHelper.GetOperationResponse(false, "Unable to find template"));
             }
             if (existingRecord.Supplies.Any())
             {
@@ -98,11 +98,11 @@ namespace CarCareTracker.Controllers
                 var supplyAvailability = CheckSupplyRecordsAvailability(existingRecord.Supplies);
                 if (supplyAvailability.Any(x => x.Missing))
                 {
-                    return Json(new OperationResponse { Success = false, Message = "Missing Supplies, Please Delete This Template and Recreate It." });
+                    return Json(StaticHelper.GetOperationResponse(false, "Missing Supplies, Please Delete This Template and Recreate It."));
                 }
                 else if (supplyAvailability.Any(x => x.Insufficient))
                 {
-                    return Json(new OperationResponse { Success = false, Message = "Insufficient Supplies" });
+                    return Json(StaticHelper.GetOperationResponse(false, "Insufficient Supplies"));
                 }
             }
             if (existingRecord.ReminderRecordId != default)
@@ -111,7 +111,7 @@ namespace CarCareTracker.Controllers
                 var existingReminder = _reminderRecordDataAccess.GetReminderRecordById(existingRecord.ReminderRecordId);
                 if (existingReminder is null || existingReminder.Id == default || !existingReminder.IsRecurring)
                 {
-                    return Json(new OperationResponse { Success = false, Message = "Missing or Non-recurring Reminder, Please Delete This Template and Recreate It." });
+                    return Json(StaticHelper.GetOperationResponse(false, "Missing or Non-recurring Reminder, Please Delete This Template and Recreate It."));
                 }
             }
             //populate createdDate
@@ -127,7 +127,7 @@ namespace CarCareTracker.Controllers
                 }
             }
             var result = _planRecordDataAccess.SavePlanRecordToVehicle(existingRecord.ToPlanRecord());
-            return Json(new OperationResponse { Success = result, Message = result ? "Plan Record Added" : StaticHelper.GenericErrorMessage });
+            return Json(StaticHelper.GetOperationResponse(result, result ? "Plan Record Added" : StaticHelper.GenericErrorMessage));
         }
         [HttpGet]
         public IActionResult GetAddPlanRecordPartialView()

--- a/Controllers/Vehicle/ReportController.cs
+++ b/Controllers/Vehicle/ReportController.cs
@@ -311,13 +311,13 @@ namespace CarCareTracker.Controllers
                 var result = _fileHelper.MakeAttachmentsExport(attachmentData);
                 if (string.IsNullOrWhiteSpace(result))
                 {
-                    return Json(new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage });
+                    return Json(StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage));
                 }
-                return Json(new OperationResponse { Success = true, Message = result });
+                return Json(StaticHelper.GetOperationResponse(true, result));
             }
             else
             {
-                return Json(new OperationResponse { Success = false, Message = "No Attachments Found" });
+                return Json(StaticHelper.GetOperationResponse(false, "No Attachments Found"));
             }
         }
         [TypeFilter(typeof(CollaboratorFilter))]

--- a/Controllers/VehicleController.cs
+++ b/Controllers/VehicleController.cs
@@ -188,15 +188,15 @@ namespace CarCareTracker.Controllers
                     }
                     else
                     {
-                        return Json(new OperationResponse { Success = false, Message = "Both vehicles already have identical collaborators" });
+                        return Json(StaticHelper.GetOperationResponse(false, "Both vehicles already have identical collaborators"));
                     }
                 }
-                return Json(new OperationResponse { Success = true, Message = "Collaborators Copied" });
+                return Json(StaticHelper.GetOperationResponse(true, "Collaborators Copied"));
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex.Message);
-                return Json(new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage });
+                return Json(StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage));
             }
         }
         

--- a/Helper/MailHelper.cs
+++ b/Helper/MailHelper.cs
@@ -17,6 +17,11 @@ namespace CarCareTracker.Helper
         private readonly MailConfig mailConfig;
         private readonly IFileHelper _fileHelper;
         private readonly ILogger<MailHelper> _logger;
+
+        private const string MailServerNotSetUp = "SMTP Server Not Setup";
+        private const string EmailAddressOrTokenInvalid = "Email Address or Token is invalid";
+        private const string EmailSent = "Email Sent!";
+        
         public MailHelper(
             IConfiguration config,
             IFileHelper fileHelper,
@@ -31,79 +36,80 @@ namespace CarCareTracker.Helper
         {
             if (string.IsNullOrWhiteSpace(mailConfig.EmailServer))
             {
-                return new OperationResponse { Success = false, Message = "SMTP Server Not Setup" };
+                return StaticHelper.GetOperationResponse(false, MailServerNotSetUp);
             }
-            if (string.IsNullOrWhiteSpace(emailAddress) || string.IsNullOrWhiteSpace(token)) {
-                return new OperationResponse { Success = false, Message = "Email Address or Token is invalid" };
+            if (string.IsNullOrWhiteSpace(emailAddress) || string.IsNullOrWhiteSpace(token))
+            {
+                return StaticHelper.GetOperationResponse(false, EmailAddressOrTokenInvalid);
             }
-            string emailSubject = "Your Registration Token for LubeLogger";
+            const string emailSubject = "Your Registration Token for LubeLogger";
             string emailBody = $"A token has been generated on your behalf, please complete your registration for LubeLogger using the token: {token}";
             var result = SendEmail(new List<string> { emailAddress }, emailSubject, emailBody);
             if (result)
             {
-                return new OperationResponse { Success = true, Message = "Email Sent!" };
+                return StaticHelper.GetOperationResponse(true, EmailSent);
             } else
             {
-                return new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage };
+                return StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage);
             }
         }
         public OperationResponse NotifyUserForPasswordReset(string emailAddress, string token)
         {
             if (string.IsNullOrWhiteSpace(mailConfig.EmailServer))
             {
-                return new OperationResponse { Success = false, Message = "SMTP Server Not Setup" };
+                return StaticHelper.GetOperationResponse(false, MailServerNotSetUp);
             }
             if (string.IsNullOrWhiteSpace(emailAddress) || string.IsNullOrWhiteSpace(token))
             {
-                return new OperationResponse { Success = false, Message = "Email Address or Token is invalid" };
+                return StaticHelper.GetOperationResponse(false, EmailAddressOrTokenInvalid);
             }
-            string emailSubject = "Your Password Reset Token for LubeLogger";
+            const string emailSubject = "Your Password Reset Token for LubeLogger";
             string emailBody = $"A token has been generated on your behalf, please reset your password for LubeLogger using the token: {token}";
             var result = SendEmail(new List<string> { emailAddress }, emailSubject, emailBody);
             if (result)
             {
-                return new OperationResponse { Success = true, Message = "Email Sent!" };
+                return StaticHelper.GetOperationResponse(true, EmailSent);
             }
             else
             {
-                return new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage };
+                return StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage);
             }
         }
         public OperationResponse NotifyUserForAccountUpdate(string emailAddress, string token)
         {
             if (string.IsNullOrWhiteSpace(mailConfig.EmailServer))
             {
-                return new OperationResponse { Success = false, Message = "SMTP Server Not Setup" };
+                return StaticHelper.GetOperationResponse(false, MailServerNotSetUp);
             }
             if (string.IsNullOrWhiteSpace(emailAddress) || string.IsNullOrWhiteSpace(token))
             {
-                return new OperationResponse { Success = false, Message = "Email Address or Token is invalid" };
+                return StaticHelper.GetOperationResponse(false, EmailAddressOrTokenInvalid);
             }
-            string emailSubject = "Your User Account Update Token for LubeLogger";
+            const string emailSubject = "Your User Account Update Token for LubeLogger";
             string emailBody = $"A token has been generated on your behalf, please update your account for LubeLogger using the token: {token}";
             var result = SendEmail(new List<string> { emailAddress}, emailSubject, emailBody);
             if (result)
             {
-                return new OperationResponse { Success = true, Message = "Email Sent!" };
+                return StaticHelper.GetOperationResponse(true, EmailSent);
             }
             else
             {
-                return new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage };
+                return StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage);
             }
         }
         public OperationResponse NotifyUserForReminders(Vehicle vehicle, List<string> emailAddresses, List<ReminderRecordViewModel> reminders)
         {
             if (string.IsNullOrWhiteSpace(mailConfig.EmailServer))
             {
-                return new OperationResponse { Success = false, Message = "SMTP Server Not Setup" };
+                return StaticHelper.GetOperationResponse(false, MailServerNotSetUp);
             }
             if (!emailAddresses.Any())
             {
-                return new OperationResponse { Success = false, Message = "No recipients could be found" };
+                return StaticHelper.GetOperationResponse(false, "No recipients could be found");
             }
             if (!reminders.Any())
             {
-                return new OperationResponse { Success = false, Message = "No reminders could be found" };
+                return StaticHelper.GetOperationResponse(false, "No reminders could be found");
             }
             //get email template, this file has to exist since it's a static file.
             var emailTemplatePath = _fileHelper.GetFullFilePath(StaticHelper.ReminderEmailTemplate);
@@ -114,7 +120,12 @@ namespace CarCareTracker.Helper
             string tableBody = "";
             foreach(ReminderRecordViewModel reminder in reminders)
             {
-                var dueOn = reminder.Metric == ReminderMetric.Both ? $"{reminder.Date.ToShortDateString()} or {reminder.Mileage}" : reminder.Metric == ReminderMetric.Date ? $"{reminder.Date.ToShortDateString()}" : $"{reminder.Mileage}";
+                var dueOn = reminder.Metric switch
+                {
+                    ReminderMetric.Both => $"{reminder.Date.ToShortDateString()} or {reminder.Mileage}",
+                    ReminderMetric.Date => $"{reminder.Date.ToShortDateString()}",
+                    _ => $"{reminder.Mileage}"
+                };
                 tableBody += $"<tr class='{reminder.Urgency}'><td>{StaticHelper.GetTitleCaseReminderUrgency(reminder.Urgency)}</td><td>{reminder.Description}</td><td>{dueOn}</td></tr>";
             }
             emailBody = emailBody.Replace("{TableBody}", tableBody);
@@ -123,14 +134,14 @@ namespace CarCareTracker.Helper
                 var result = SendEmail(emailAddresses, emailSubject, emailBody);
                 if (result)
                 {
-                    return new OperationResponse { Success = true, Message = "Email Sent!" };
+                    return StaticHelper.GetOperationResponse(true, EmailSent);
                 } else
                 {
-                    return new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage };
+                    return StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage);
                 }
             } catch (Exception ex)
             {
-                return new OperationResponse { Success = false, Message = ex.Message };
+                return StaticHelper.GetOperationResponse(false, ex.Message);
             }
         }
         private bool SendEmail(List<string> emailTo, string emailSubject, string emailBody) {
@@ -144,9 +155,10 @@ namespace CarCareTracker.Helper
             }
             message.Subject = emailSubject;
 
-            var builder = new BodyBuilder();
-
-            builder.HtmlBody = emailBody;
+            var builder = new BodyBuilder
+            {
+                HtmlBody = emailBody
+            };
 
             message.Body = builder.ToMessageBody();
 

--- a/Helper/StaticHelper.cs
+++ b/Helper/StaticHelper.cs
@@ -9,16 +9,17 @@ namespace CarCareTracker.Helper
     /// </summary>
     public static class StaticHelper
     {
-        public static string VersionNumber = "1.4.0";
-        public static string DbName = "data/cartracker.db";
-        public static string UserConfigPath = "config/userConfig.json";
-        public static string AdditionalWidgetsPath = "data/widgets.html";
-        public static string GenericErrorMessage = "An error occurred, please try again later";
-        public static string ReminderEmailTemplate = "defaults/reminderemailtemplate.txt";
-        public static string DefaultAllowedFileExtensions = ".png,.jpg,.jpeg,.pdf,.xls,.xlsx,.docx";
-        public static string SponsorsPath = "https://hargata.github.io/hargata/sponsors.json";
-        public static string TranslationPath = "https://hargata.github.io/lubelog_translations";
-        public static string TranslationDirectoryPath = $"{TranslationPath}/directory.json";
+        public const string VersionNumber = "1.4.0";
+        public const string DbName = "data/cartracker.db";
+        public const string UserConfigPath = "config/userConfig.json";
+        public const string AdditionalWidgetsPath = "data/widgets.html";
+        public const string GenericErrorMessage = "An error occurred, please try again later";
+        public const string ReminderEmailTemplate = "defaults/reminderemailtemplate.txt";
+        public const string DefaultAllowedFileExtensions = ".png,.jpg,.jpeg,.pdf,.xls,.xlsx,.docx";
+        public const string SponsorsPath = "https://hargata.github.io/hargata/sponsors.json";
+        private const string TranslationPath = "https://hargata.github.io/lubelog_translations";
+        public const string TranslationDirectoryPath = $"{TranslationPath}/directory.json";
+        
         public static string GetTitleCaseReminderUrgency(ReminderUrgency input)
         {
             switch (input)
@@ -102,7 +103,7 @@ namespace CarCareTracker.Helper
             }
             if (input.Length > maxLength)
             {
-                return (input.Substring(0, maxLength) + "...");
+                return (string.Concat(input.AsSpan(0, maxLength), "..."));
             }
             else
             {
@@ -329,7 +330,7 @@ namespace CarCareTracker.Helper
                 {
                 { "vehicleId", vehicleId.ToString() },
                      { "username", username },
-                     { "action", action },
+                     { "action", action }
                 };
             httpClient.PostAsJsonAsync(webhookURL, httpParams);
         }
@@ -424,7 +425,7 @@ namespace CarCareTracker.Helper
             { 
                 try
                 {
-                    string cleanedName = name.Contains("_") ? name.Replace("_", "-") : name;
+                    string cleanedName = name.Contains('_') ? name.Replace("_", "-") : name;
                     string displayName = CultureInfo.GetCultureInfo(cleanedName).DisplayName;
                     if (string.IsNullOrWhiteSpace(displayName))
                     {
@@ -434,7 +435,7 @@ namespace CarCareTracker.Helper
                     {
                         return displayName;
                     }
-                } catch (Exception ex)
+                } catch (Exception)
                 {
                     return name;
                 }
@@ -636,6 +637,11 @@ namespace CarCareTracker.Helper
                 }
                 _csv.NextRecord();
             }
+        }
+
+        internal static OperationResponse GetOperationResponse(bool success, string message)
+        {
+            return new OperationResponse { Success = success, Message = message };
         }
     }
 }

--- a/Helper/TranslationHelper.cs
+++ b/Helper/TranslationHelper.cs
@@ -125,15 +125,15 @@ namespace CarCareTracker.Helper
         {
             if (userLanguage == "en_US")
             {
-                return new OperationResponse { Success = false, Message = "The translation file name en_US is reserved." };
+                return StaticHelper.GetOperationResponse(false, "The translation file name en_US is reserved.");
             }
             if (string.IsNullOrWhiteSpace(userLanguage))
             {
-                return new OperationResponse { Success = false, Message = "File name is not provided." };
+                return StaticHelper.GetOperationResponse(false, "File name is not provided.");
             }
             if (!translations.Any())
             {
-                return new OperationResponse { Success = false, Message = "Translation has no data." };
+                return StaticHelper.GetOperationResponse(false, "Translation has no data.");
             }
             var translationFilePath = _fileHelper.GetFullFilePath($"/translations/{userLanguage}.json", false);
             try
@@ -154,12 +154,12 @@ namespace CarCareTracker.Helper
                     //write to file
                     File.WriteAllText(translationFilePath, JsonSerializer.Serialize(translations));
                 }
-                return new OperationResponse { Success = true, Message = "Translation Updated" };
+                return StaticHelper.GetOperationResponse(true, "Translation Updated");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex.Message);
-                return new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage };
+                return StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage);
             }
         }
         public string ExportTranslation(Dictionary<string, string> translations)

--- a/Logic/UserLogic.cs
+++ b/Logic/UserLogic.cs
@@ -51,16 +51,16 @@ namespace CarCareTracker.Logic
                 var userAccess = _userAccess.GetUserAccessByVehicleAndUserId(existingUser.Id, vehicleId);
                 if (userAccess != null)
                 {
-                    return new OperationResponse { Success = false, Message = "User is already a collaborator" };
+                    return StaticHelper.GetOperationResponse(false, "User is already a collaborator");
                 }
                 var result = AddUserAccessToVehicle(existingUser.Id, vehicleId);
                 if (result)
                 {
-                    return new OperationResponse { Success = true, Message = "Collaborator Added" };
+                    return StaticHelper.GetOperationResponse(true, "Collaborator Added");
                 }
-                return new OperationResponse { Success = false, Message = StaticHelper.GenericErrorMessage };
+                return StaticHelper.GetOperationResponse(false, StaticHelper.GenericErrorMessage);
             }
-            return new OperationResponse { Success = false, Message = $"Unable to find user {username} in the system" };
+            return StaticHelper.GetOperationResponse(false, $"Unable to find user {username} in the system");
         }
         public bool DeleteCollaboratorFromVehicle(int userId, int vehicleId)
         {


### PR DESCRIPTION
The main change is to replace all calls of "new OperationResponse" to a new static method in StaticHelper.cs.
The most are listed here except for a few small changes like introducing a string variable for an often used string or something similar.

I hope thats not too much for one PR, otherwise let me know which files I should revert for now.

StaticHelper:
- Line 12-21: Changing public static strings to const because of [CA2211: Non-constant fields should not be visible](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2211)
- Line 106: Replaced input.Substring(0, maxLength) + "...") with string.Concat(input.AsSpan(0, maxLength), "...") because of [CA1845: Use span-based 'string.Concat'](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1845)
- Line 428: Replaced "\_" with '\_' because of [CA1847: Use String.Contains(char) instead of String.Contains(string) with single characters](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1847)
- Line 641: Added a static method to reuse "new OperationResponse { Success = success, Message = message}" for reusage, readability, maintainability, reducing redundancy

APIController:
- Replaced "new OperationResponse..." with the new static method from StaticHelper
- Added a method for the often used "Must provide a valid vehicle id" response in APIController

LoginLogic.cs:
- Replaced "new OperationResponse..." with the new static method from StaticHelper
- Made methods "GetRootUserData" & "NewToken" static because of [CA1822: Mark members as static](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822)
- Line 464: Replaced "SHA256.Create().ComputeHash(verifierBytes);" with static "SHA256.HashData(verifierBytes);" because of [CA1850: Prefer static HashData method over ComputeHash](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1850)

MailHelper.cs:
- Replaced "new OperationResponse..." with the new static method from StaticHelper
- Line 123-128: Replaced hard to read code line with switch statement

The 10 other files (TranslationHelper, UserLogic, Plan-, Report-, Admin-, Files-, Home-, Migration- & VehicleController)
- Replaced "new OperationResponse..." with the new static method from StaticHelper