### PR TITLE
Replenish Supplies By Deleting Records

### DIFF
--- a/Controllers/Vehicle/GasController.cs
+++ b/Controllers/Vehicle/GasController.cs
@@ -91,10 +91,21 @@ namespace CarCareTracker.Controllers
             };
             return PartialView("_GasModal", viewModel);
         }
+        private bool DeleteGasRecordWithChecks(int gasRecordId)
+        {
+            var existingRecord = _gasRecordDataAccess.GetGasRecordById(gasRecordId);
+            //security check.
+            if (!_userLogic.UserCanEditVehicle(GetUserID(), existingRecord.VehicleId))
+            {
+                return false;
+            }
+            var result = _gasRecordDataAccess.DeleteGasRecordById(existingRecord.Id);
+            return result;
+        }
         [HttpPost]
         public IActionResult DeleteGasRecordById(int gasRecordId)
         {
-            var result = _gasRecordDataAccess.DeleteGasRecordById(gasRecordId);
+            var result = DeleteGasRecordWithChecks(gasRecordId);
             if (result)
             {
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), 0, User.Identity.Name, $"Deleted Gas Record - Id: {gasRecordId}");

--- a/Controllers/Vehicle/NoteController.cs
+++ b/Controllers/Vehicle/NoteController.cs
@@ -45,10 +45,21 @@ namespace CarCareTracker.Controllers
             var result = _noteDataAccess.GetNoteById(noteId);
             return PartialView("_NoteModal", result);
         }
+        private bool DeleteNoteWithChecks(int noteId)
+        {
+            var existingRecord = _noteDataAccess.GetNoteById(noteId);
+            //security check.
+            if (!_userLogic.UserCanEditVehicle(GetUserID(), existingRecord.VehicleId))
+            {
+                return false;
+            }
+            var result = _noteDataAccess.DeleteNoteById(existingRecord.Id);
+            return result;
+        }
         [HttpPost]
         public IActionResult DeleteNoteById(int noteId)
         {
-            var result = _noteDataAccess.DeleteNoteById(noteId);
+            var result = DeleteNoteWithChecks(noteId);
             if (result)
             {
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), 0, User.Identity.Name, $"Deleted Note - Id: {noteId}");

--- a/Controllers/Vehicle/OdometerController.cs
+++ b/Controllers/Vehicle/OdometerController.cs
@@ -140,10 +140,21 @@ namespace CarCareTracker.Controllers
             };
             return PartialView("_OdometerRecordModal", convertedResult);
         }
+        private bool DeleteOdometerRecordWithChecks(int odometerRecordId)
+        {
+            var existingRecord = _odometerRecordDataAccess.GetOdometerRecordById(odometerRecordId);
+            //security check.
+            if (!_userLogic.UserCanEditVehicle(GetUserID(), existingRecord.VehicleId))
+            {
+                return false;
+            }
+            var result = _odometerRecordDataAccess.DeleteOdometerRecordById(existingRecord.Id);
+            return result;
+        }
         [HttpPost]
         public IActionResult DeleteOdometerRecordById(int odometerRecordId)
         {
-            var result = _odometerRecordDataAccess.DeleteOdometerRecordById(odometerRecordId);
+            var result = DeleteOdometerRecordWithChecks(odometerRecordId);
             if (result)
             {
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), 0, User.Identity.Name, $"Deleted Odometer Record - Id: {odometerRecordId}");

--- a/Controllers/Vehicle/ReminderController.cs
+++ b/Controllers/Vehicle/ReminderController.cs
@@ -149,10 +149,21 @@ namespace CarCareTracker.Controllers
             };
             return PartialView("_ReminderRecordModal", convertedResult);
         }
+        private bool DeleteReminderRecordWithChecks(int reminderRecordId)
+        {
+            var existingRecord = _reminderRecordDataAccess.GetReminderRecordById(reminderRecordId);
+            //security check.
+            if (!_userLogic.UserCanEditVehicle(GetUserID(), existingRecord.VehicleId))
+            {
+                return false;
+            }
+            var result = _reminderRecordDataAccess.DeleteReminderRecordById(existingRecord.Id);
+            return result;
+        }
         [HttpPost]
         public IActionResult DeleteReminderRecordById(int reminderRecordId)
         {
-            var result = _reminderRecordDataAccess.DeleteReminderRecordById(reminderRecordId);
+            var result = DeleteReminderRecordWithChecks(reminderRecordId);
             if (result)
             {
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), 0, User.Identity.Name, $"Deleted Reminder - Id: {reminderRecordId}");

--- a/Controllers/Vehicle/SupplyController.cs
+++ b/Controllers/Vehicle/SupplyController.cs
@@ -227,10 +227,13 @@ namespace CarCareTracker.Controllers
         private bool DeleteSupplyRecordWithChecks(int supplyRecordId)
         {
             var existingRecord = _supplyRecordDataAccess.GetSupplyRecordById(supplyRecordId);
-            //security check.
-            if (!_userLogic.UserCanEditVehicle(GetUserID(), existingRecord.VehicleId))
+            if (existingRecord.VehicleId != default)
             {
-                return false;
+                //security check only if not editing shop supply.
+                if (!_userLogic.UserCanEditVehicle(GetUserID(), existingRecord.VehicleId))
+                {
+                    return false;
+                }
             }
             var result = _supplyRecordDataAccess.DeleteSupplyRecordById(existingRecord.Id);
             return result;

--- a/Controllers/Vehicle/SupplyController.cs
+++ b/Controllers/Vehicle/SupplyController.cs
@@ -58,6 +58,7 @@ namespace CarCareTracker.Controllers
                 //create new requisitionrrecord
                 var requisitionRecord = new SupplyUsageHistory
                 {
+                    Id = supply.SupplyId,
                     Date = dateRequisitioned,
                     Description = usageDescription,
                     Quantity = supply.Quantity,
@@ -71,6 +72,44 @@ namespace CarCareTracker.Controllers
                 results.Add(requisitionRecord);
             }
             return results;
+        }
+        private void RestoreSupplyRecordsByUsage(List<SupplyUsageHistory> supplyUsage, string usageDescription)
+        {
+            foreach (SupplyUsageHistory supply in supplyUsage)
+            {
+                try
+                {
+                    if (supply.Id == default)
+                    {
+                        continue; //no id, skip current supply.
+                    }
+                    var result = _supplyRecordDataAccess.GetSupplyRecordById(supply.Id);
+                    if (result != null && result.Id != default)
+                    {
+                        //supply exists, re-add the quantity and cost
+                        result.Quantity += supply.Quantity;
+                        result.Cost += supply.Cost;
+                        var requisitionRecord = new SupplyUsageHistory
+                        {
+                            Id = supply.Id,
+                            Date = DateTime.Now.Date,
+                            Description = $"Restored from {usageDescription}",
+                            Quantity = supply.Quantity,
+                            Cost = supply.Cost
+                        };
+                        result.RequisitionHistory.Add(requisitionRecord);
+                        //save
+                        _supplyRecordDataAccess.SaveSupplyRecordToVehicle(result);
+                    }
+                    else
+                    {
+                        _logger.LogError($"Unable to find supply with id {supply.Id}");
+                    }
+                } catch (Exception ex)
+                {
+                    _logger.LogError($"Error restoring supply with id {supply.Id} : {ex.Message}");
+                }
+            }
         }
         [TypeFilter(typeof(CollaboratorFilter))]
         [HttpGet]
@@ -161,6 +200,11 @@ namespace CarCareTracker.Controllers
         public IActionResult GetSupplyRecordForEditById(int supplyRecordId)
         {
             var result = _supplyRecordDataAccess.GetSupplyRecordById(supplyRecordId);
+            if (result.RequisitionHistory.Any())
+            {
+                //requisition history when viewed through the supply is always immutable.
+                result.RequisitionHistory = result.RequisitionHistory.Select(x => new SupplyUsageHistory { Id = default, Cost = x.Cost, Description = x.Description, Date = x.Date, PartNumber = x.PartNumber, Quantity = x.Quantity }).ToList();
+            }
             //convert to Input object.
             var convertedResult = new SupplyRecordInput
             {
@@ -180,10 +224,21 @@ namespace CarCareTracker.Controllers
             };
             return PartialView("_SupplyRecordModal", convertedResult);
         }
+        private bool DeleteSupplyRecordWithChecks(int supplyRecordId)
+        {
+            var existingRecord = _supplyRecordDataAccess.GetSupplyRecordById(supplyRecordId);
+            //security check.
+            if (!_userLogic.UserCanEditVehicle(GetUserID(), existingRecord.VehicleId))
+            {
+                return false;
+            }
+            var result = _supplyRecordDataAccess.DeleteSupplyRecordById(existingRecord.Id);
+            return result;
+        }
         [HttpPost]
         public IActionResult DeleteSupplyRecordById(int supplyRecordId)
         {
-            var result = _supplyRecordDataAccess.DeleteSupplyRecordById(supplyRecordId);
+            var result = DeleteSupplyRecordWithChecks(supplyRecordId);
             if (result)
             {
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), 0, User.Identity.Name, $"Deleted Supply Record - Id: {supplyRecordId}");

--- a/Controllers/Vehicle/TaxController.cs
+++ b/Controllers/Vehicle/TaxController.cs
@@ -110,10 +110,21 @@ namespace CarCareTracker.Controllers
             };
             return PartialView("_TaxRecordModal", convertedResult);
         }
+        private bool DeleteTaxRecordWithChecks(int taxRecordId)
+        {
+            var existingRecord = _taxRecordDataAccess.GetTaxRecordById(taxRecordId);
+            //security check.
+            if (!_userLogic.UserCanEditVehicle(GetUserID(), existingRecord.VehicleId))
+            {
+                return false;
+            }
+            var result = _taxRecordDataAccess.DeleteTaxRecordById(existingRecord.Id);
+            return result;
+        }
         [HttpPost]
         public IActionResult DeleteTaxRecordById(int taxRecordId)
         {
-            var result = _taxRecordDataAccess.DeleteTaxRecordById(taxRecordId);
+            var result = DeleteTaxRecordWithChecks(taxRecordId);
             if (result)
             {
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), 0, User.Identity.Name, $"Deleted Tax Record - Id: {taxRecordId}");

--- a/Controllers/VehicleController.cs
+++ b/Controllers/VehicleController.cs
@@ -401,31 +401,31 @@ namespace CarCareTracker.Controllers
                 switch (importMode)
                 {
                     case ImportMode.ServiceRecord:
-                        result = _serviceRecordDataAccess.DeleteServiceRecordById(recordId);
+                        result = DeleteServiceRecordWithChecks(recordId);
                         break;
                     case ImportMode.RepairRecord:
-                        result = _collisionRecordDataAccess.DeleteCollisionRecordById(recordId);
+                        result = DeleteCollisionRecordWithChecks(recordId);
                         break;
                     case ImportMode.UpgradeRecord:
-                        result = _upgradeRecordDataAccess.DeleteUpgradeRecordById(recordId);
+                        result = DeleteUpgradeRecordWithChecks(recordId);
                         break;
                     case ImportMode.GasRecord:
-                        result = _gasRecordDataAccess.DeleteGasRecordById(recordId);
+                        result = DeleteGasRecordWithChecks(recordId);
                         break;
                     case ImportMode.TaxRecord:
-                        result = _taxRecordDataAccess.DeleteTaxRecordById(recordId);
+                        result = DeleteTaxRecordWithChecks(recordId);
                         break;
                     case ImportMode.SupplyRecord:
-                        result = _supplyRecordDataAccess.DeleteSupplyRecordById(recordId);
+                        result = DeleteSupplyRecordWithChecks(recordId);
                         break;
                     case ImportMode.NoteRecord:
-                        result = _noteDataAccess.DeleteNoteById(recordId);
+                        result = DeleteNoteWithChecks(recordId);
                         break;
                     case ImportMode.OdometerRecord:
-                        result = _odometerRecordDataAccess.DeleteOdometerRecordById(recordId);
+                        result = DeleteOdometerRecordWithChecks(recordId);
                         break;
                     case ImportMode.ReminderRecord:
-                        result = _reminderRecordDataAccess.DeleteReminderRecordById(recordId);
+                        result = DeleteReminderRecordWithChecks(recordId);
                         break;
                 }
             }

--- a/Logic/VehicleLogic.cs
+++ b/Logic/VehicleLogic.cs
@@ -311,7 +311,7 @@ namespace CarCareTracker.Logic
                 }
                 if (vehiclePlans.Any())
                 {
-                    var convertedPlans = vehiclePlans.Select(x => new PlanRecord { Priority = x.Priority, Progress = x.Progress, Notes = x.Notes, RequisitionHistory = x.RequisitionHistory, Description = $"{vehicle.Year} {vehicle.Make} {vehicle.Model} #{StaticHelper.GetVehicleIdentifier(vehicle)} - {x.Description}" });
+                    var convertedPlans = vehiclePlans.Select(x => new PlanRecord { ImportMode = x.ImportMode, Priority = x.Priority, Progress = x.Progress, Notes = x.Notes, RequisitionHistory = x.RequisitionHistory, Description = $"{vehicle.Year} {vehicle.Make} {vehicle.Model} #{StaticHelper.GetVehicleIdentifier(vehicle)} - {x.Description}" });
                     plans.AddRange(convertedPlans);
                 }
             }

--- a/Models/Collision/CollisionRecordInput.cs
+++ b/Models/Collision/CollisionRecordInput.cs
@@ -15,6 +15,7 @@
         public List<string> Tags { get; set; } = new List<string>();
         public List<ExtraField> ExtraFields { get; set; } = new List<ExtraField>();
         public List<SupplyUsageHistory> RequisitionHistory { get; set; } = new List<SupplyUsageHistory>();
+        public List<SupplyUsageHistory> DeletedRequisitionHistory { get; set; } = new List<SupplyUsageHistory>();
         public bool CopySuppliesAttachment { get; set; } = false;
         public CollisionRecord ToCollisionRecord() { return new CollisionRecord { 
             Id = Id, 

--- a/Models/PlanRecord/PlanRecordInput.cs
+++ b/Models/PlanRecord/PlanRecordInput.cs
@@ -17,6 +17,7 @@
         public decimal Cost { get; set; }
         public List<ExtraField> ExtraFields { get; set; } = new List<ExtraField>();
         public List<SupplyUsageHistory> RequisitionHistory { get; set; } = new List<SupplyUsageHistory>();
+        public List<SupplyUsageHistory> DeletedRequisitionHistory { get; set; } = new List<SupplyUsageHistory>();
         public bool CopySuppliesAttachment { get; set; } = false;
         public PlanRecord ToPlanRecord() { return new PlanRecord { 
             Id = Id, 

--- a/Models/ServiceRecord/ServiceRecordInput.cs
+++ b/Models/ServiceRecord/ServiceRecordInput.cs
@@ -15,6 +15,7 @@
         public List<string> Tags { get; set; } = new List<string>();
         public List<ExtraField> ExtraFields { get; set; } = new List<ExtraField>();
         public List<SupplyUsageHistory> RequisitionHistory { get; set; } = new List<SupplyUsageHistory>();
+        public List<SupplyUsageHistory> DeletedRequisitionHistory { get; set; } = new List<SupplyUsageHistory>();
         public bool CopySuppliesAttachment { get; set; } = false;
         public ServiceRecord ToServiceRecord() { return new ServiceRecord { 
             Id = Id, 

--- a/Models/Supply/SupplyUsageHistory.cs
+++ b/Models/Supply/SupplyUsageHistory.cs
@@ -1,6 +1,7 @@
 ﻿namespace CarCareTracker.Models
 {
     public class SupplyUsageHistory {
+        public int Id { get; set; }
         public DateTime Date { get; set; }
         public string PartNumber { get; set; }
         public string Description { get; set; }

--- a/Models/UpgradeRecord/UpgradeReportInput.cs
+++ b/Models/UpgradeRecord/UpgradeReportInput.cs
@@ -15,6 +15,7 @@
         public List<string> Tags { get; set; } = new List<string>();
         public List<ExtraField> ExtraFields { get; set; } = new List<ExtraField>();
         public List<SupplyUsageHistory> RequisitionHistory { get; set; } = new List<SupplyUsageHistory>();
+        public List<SupplyUsageHistory> DeletedRequisitionHistory { get; set; } = new List<SupplyUsageHistory>();
         public bool CopySuppliesAttachment { get; set; } = false;
         public UpgradeRecord ToUpgradeRecord() { return new UpgradeRecord { 
             Id = Id, 

--- a/Views/Vehicle/_SupplyRequisitionHistory.cshtml
+++ b/Views/Vehicle/_SupplyRequisitionHistory.cshtml
@@ -1,13 +1,25 @@
 ﻿@using CarCareTracker.Helper
 @inject IConfigHelper config
 @inject ITranslationHelper translator
+@model List<SupplyUsageHistory>
 @{
     var userConfig = config.GetUserConfig(User);
     var userLanguage = userConfig.UserLanguage;
+    var showDelete = Model.All(x => x.Id != default);
+    var showPartNumber = Model.Any(x => !string.IsNullOrWhiteSpace(x.PartNumber));
 }
-@model List<SupplyUsageHistory>
 <script>
     var supplyUsageHistory = [];
+    var deletedSupplyUsageHistory = [];
+    function deleteSupplyUsageHistory(supplyId, quantity, cost, supplyRow){
+        deletedSupplyUsageHistory.push({
+            id: decodeHTMLEntities(supplyId),
+            quantity: decodeHTMLEntities(quantity),
+            cost: decodeHTMLEntities(cost)
+        });
+        supplyUsageHistory = supplyUsageHistory.filter(x=>x.id != decodeHTMLEntities(supplyId));
+        $(supplyRow).parents(".supply-row").remove();
+    }
 </script>
 <div id="supplyUsageHistoryModalContainer" class="d-none">
     <div class="modal-header">
@@ -22,35 +34,43 @@
                         <thead class="sticky-top">
                             <tr class="d-flex">
                                 <th scope="col" class="col-2">@translator.Translate(userLanguage, "Date")</th>
-                                @if(Model.Any(x=>!string.IsNullOrWhiteSpace(x.PartNumber))){
+                                @if(showPartNumber){
                                     <th scope="col" class="col-2">@translator.Translate(userLanguage, "Part Number")</th>
-                                    <th scope="col" class="col-4">@translator.Translate(userLanguage, "Description")</th>
+                                    <th scope="col" class="@(showDelete ? "col-2" : "col-4")">@translator.Translate(userLanguage, "Description")</th>
                                 } else
                                 {
-                                    <th scope="col" class="col-6">@translator.Translate(userLanguage, "Description")</th>
+                                    <th scope="col" class="@(showDelete ? "col-4" : "col-6")">@translator.Translate(userLanguage, "Description")</th>
                                 }
                                 <th scope="col" class="col-2">@translator.Translate(userLanguage, "Quantity")</th>
                                 <th scope="col" class="col-2">@translator.Translate(userLanguage, "Cost")</th>
+                                @if (showDelete){
+                                    <th scope="col" class="col-2">@translator.Translate(userLanguage, "Delete")</th>
+                                }
                             </tr>
                         </thead>
                         <tbody>
                             @foreach (SupplyUsageHistory usageHistory in Model)
                             {
                                 <script>
-                                    supplyUsageHistory.push({ date: decodeHTMLEntities("@usageHistory.Date.ToShortDateString()"), partNumber: decodeHTMLEntities('@usageHistory.PartNumber'), description: decodeHTMLEntities("@usageHistory.Description"), quantity: decodeHTMLEntities("@usageHistory.Quantity.ToString("F")"), cost: decodeHTMLEntities("@usageHistory.Cost.ToString("F")") })
+                                    supplyUsageHistory.push({ id: decodeHTMLEntities("@usageHistory.Id"), date: decodeHTMLEntities("@usageHistory.Date.ToShortDateString()"), partNumber: decodeHTMLEntities('@usageHistory.PartNumber'), description: decodeHTMLEntities("@usageHistory.Description"), quantity: decodeHTMLEntities("@usageHistory.Quantity.ToString("F")"), cost: decodeHTMLEntities("@usageHistory.Cost.ToString("F")") })
                                 </script>
-                                <tr class="d-flex">
+                                <tr class="d-flex supply-row">
                                     <td class="col-2">@StaticHelper.TruncateStrings(usageHistory.Date.ToShortDateString())</td>
-                                    @if (!string.IsNullOrWhiteSpace(usageHistory.PartNumber))
+                                    @if (showPartNumber)
                                     {
                                         <td class="col-2 text-truncate">@StaticHelper.TruncateStrings(usageHistory.PartNumber)</td>
-                                        <td class="col-4 text-truncate">@StaticHelper.TruncateStrings(usageHistory.Description)</td>
+                                        <td class="@(showDelete ? "col-2" : "col-4") text-truncate">@StaticHelper.TruncateStrings(usageHistory.Description)</td>
                                     } else
                                     {
-                                        <td class="col-6 text-truncate">@StaticHelper.TruncateStrings(usageHistory.Description, 50)</td>
+                                        <td class="@(showDelete ? "col-4" : "col-6") text-truncate">@StaticHelper.TruncateStrings(usageHistory.Description, 50)</td>
                                     }
                                     <td class="col-2">@usageHistory.Quantity.ToString("F")</td>
                                     <td class="col-2">@usageHistory.Cost.ToString("C2")</td>
+                                    @if (showDelete){
+                                        <td class="col-2">
+                                            <button type="button" class="btn btn-danger" onclick="deleteSupplyUsageHistory('@usageHistory.Id.ToString()', '@usageHistory.Quantity.ToString("F")', '@usageHistory.Cost.ToString("F")', this)"><i class="bi bi-trash"></i></button>
+                                        </td>
+                                    }
                                 </tr>
                             }
                         </tbody>

--- a/wwwroot/js/collisionrecord.js
+++ b/wwwroot/js/collisionrecord.js
@@ -149,6 +149,7 @@ function getAndValidateCollisionRecordValues() {
         addReminderRecord: addReminderRecord,
         extraFields: extraFields.extraFields,
         requisitionHistory: supplyUsageHistory,
+        deletedRequisitionHistory: deletedSupplyUsageHistory,
         reminderRecordId: recurringReminderRecordId,
         copySuppliesAttachment: copySuppliesAttachments
     }

--- a/wwwroot/js/planrecord.js
+++ b/wwwroot/js/planrecord.js
@@ -250,6 +250,7 @@ function getAndValidatePlanRecordValues() {
         importMode: planType,
         extraFields: extraFields.extraFields,
         requisitionHistory: supplyUsageHistory,
+        deletedRequisitionHistory: deletedSupplyUsageHistory,
         reminderRecordId: reminderRecordId,
         copySuppliesAttachment: copySuppliesAttachments
     }

--- a/wwwroot/js/servicerecord.js
+++ b/wwwroot/js/servicerecord.js
@@ -149,6 +149,7 @@ function getAndValidateServiceRecordValues() {
         addReminderRecord: addReminderRecord,
         extraFields: extraFields.extraFields,
         requisitionHistory: supplyUsageHistory,
+        deletedRequisitionHistory: deletedSupplyUsageHistory,
         reminderRecordId: recurringReminderRecordId,
         copySuppliesAttachment: copySuppliesAttachments
     }

--- a/wwwroot/js/upgraderecord.js
+++ b/wwwroot/js/upgraderecord.js
@@ -149,6 +149,7 @@ function getAndValidateUpgradeRecordValues() {
         addReminderRecord: addReminderRecord,
         extraFields: extraFields.extraFields,
         requisitionHistory: supplyUsageHistory,
+        deletedRequisitionHistory: deletedSupplyUsageHistory,
         reminderRecordId: recurringReminderRecordId,
         copySuppliesAttachment: copySuppliesAttachments
     }


### PR DESCRIPTION
Allow users to replenish supplies by either deleting the plan/service/upgrade/repair record or by deleting the individual requisition history. This feature will only work for supplies that were requisitioned in version 1.4.1 and newer.

See #429 