### PR TITLE
Creating tax records based on a newly created recurring tax record dated in the past

### DIFF
--- a/wwwroot/js/taxrecord.js
+++ b/wwwroot/js/taxrecord.js
@@ -83,7 +83,7 @@ function saveTaxRecordToVehicle(isEdit) {
         return;
     }
     //save to db.
-    $.post('/Vehicle/SaveTaxRecordToVehicleId', { taxRecord: formValues }, function (data) {
+    $.post('/Vehicle/SaveTaxRecordToVehicleId', { taxRecordInput: formValues }, function (data) {
         if (data) {
             successToast(isEdit ? "Tax Record Updated" : "Tax Record Added.");
             hideAddTaxRecordModal();


### PR DESCRIPTION
**Changes**
Implemented logic to create tax records based on a newly created recurring tax record dated in the past.
Recurring records from the past are only generated when creating a new tax record, not if an existing one is updated, the current data structure (no foreign keys to previous tax records) makes this not reliable enough -> should we change this?
I made sure that only the last/newest tax record has recurring = true and all previous ones are false, like it's done in `UpdateRecurringTaxes(vehicleId);`.

**Current behavior**
Currently when a recurring tax record with a date in the past is created, previous records aren't inserted during the saving process.
One record a time is added each time the vehicle is reopened (see VehilceController.Index(): `UpdateRecurringTaxes(vehicleId);`, so f.e. if a recurring record was added with start date 01.01.2024 (recurring monthly), each time the vehicle is opened another month record is added until new date is < DateTime.Now.
This seems to me like a bug or not fully implemented feature, thats why I created this PR.

**Test**
I've tested all possible options (1-6 months, 1, 2, 3, 5 years and the "other" option). Tax records are created properly from the beginning and only the newest/latest tax record has recurring = true, so that future records are generated properly in the `UpdateRecurringTaxes(vehicleId);` function.

Let me know what you think or if you suggest some changes.

**Additional thoughts**
I also thought about bringing up a checkbox for the user to choose if previous records should be generated. Depends on the implementation but if the checkbox is used only for the modal then the "bug" would still exist.

This PR fixes #745 