### PR TITLE
Allow for JSON Body in POST/PUT API Methods

### DIFF
--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -388,6 +388,7 @@ namespace CarCareTracker.Controllers
                     Tags = string.IsNullOrWhiteSpace(input.Tags) ? new List<string>() : input.Tags.Split(' ').Distinct().ToList()
                 };
                 _taxRecordDataAccess.SaveTaxRecordToVehicle(taxRecord);
+                _vehicleLogic.UpdateRecurringTaxes(vehicleId);
                 StaticHelper.NotifyAsync(_config.GetWebHookUrl(), vehicleId, User.Identity.Name, $"Added Tax Record via API - Description: {taxRecord.Description}");
                 return Json(OperationResponse.Succeed("Tax Record Added"));
             }

--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -162,6 +162,11 @@ namespace CarCareTracker.Controllers
         [TypeFilter(typeof(CollaboratorFilter))]
         [HttpPost]
         [Route("/api/vehicle/servicerecords/add")]
+        [Consumes("application/json")]
+        public IActionResult AddServiceRecordJson(int vehicleId, [FromBody] GenericRecordExportModel input) => AddServiceRecord(vehicleId, input);
+        [TypeFilter(typeof(CollaboratorFilter))]
+        [HttpPost]
+        [Route("/api/vehicle/servicerecords/add")]
         public IActionResult AddServiceRecord(int vehicleId, GenericRecordExportModel input)
         {
             if (vehicleId == default)
@@ -211,6 +216,10 @@ namespace CarCareTracker.Controllers
                 return Json(OperationResponse.Failed(ex.Message));
             }
         }
+        [HttpPut]
+        [Route("/api/vehicle/servicerecords/update")]
+        [Consumes("application/json")]
+        public IActionResult UpdateServiceRecordJson([FromBody] GenericRecordExportModel input) => UpdateServiceRecord(input);
         [HttpPut]
         [Route("/api/vehicle/servicerecords/update")]
         public IActionResult UpdateServiceRecord(GenericRecordExportModel input)
@@ -278,6 +287,11 @@ namespace CarCareTracker.Controllers
         [TypeFilter(typeof(CollaboratorFilter))]
         [HttpPost]
         [Route("/api/vehicle/repairrecords/add")]
+        [Consumes("application/json")]
+        public IActionResult AddRepairRecordJson(int vehicleId, [FromBody] GenericRecordExportModel input) => AddRepairRecord(vehicleId, input);
+        [TypeFilter(typeof(CollaboratorFilter))]
+        [HttpPost]
+        [Route("/api/vehicle/repairrecords/add")]
         public IActionResult AddRepairRecord(int vehicleId, GenericRecordExportModel input)
         {
             if (vehicleId == default)
@@ -327,6 +341,10 @@ namespace CarCareTracker.Controllers
                 return Json(OperationResponse.Failed(ex.Message));
             }
         }
+        [HttpPut]
+        [Route("/api/vehicle/repairrecords/update")]
+        [Consumes("application/json")]
+        public IActionResult UpdateRepairRecordJson([FromBody] GenericRecordExportModel input) => UpdateRepairRecord(input);
         [HttpPut]
         [Route("/api/vehicle/repairrecords/update")]
         public IActionResult UpdateRepairRecord(GenericRecordExportModel input)
@@ -395,6 +413,11 @@ namespace CarCareTracker.Controllers
         [TypeFilter(typeof(CollaboratorFilter))]
         [HttpPost]
         [Route("/api/vehicle/upgraderecords/add")]
+        [Consumes("application/json")]
+        public IActionResult AddUpgradeRecordJson(int vehicleId, [FromBody] GenericRecordExportModel input) => AddUpgradeRecord(vehicleId, input);
+        [TypeFilter(typeof(CollaboratorFilter))]
+        [HttpPost]
+        [Route("/api/vehicle/upgraderecords/add")]
         public IActionResult AddUpgradeRecord(int vehicleId, GenericRecordExportModel input)
         {
             if (vehicleId == default)
@@ -444,6 +467,10 @@ namespace CarCareTracker.Controllers
                 return Json(OperationResponse.Failed(ex.Message));
             }
         }
+        [HttpPut]
+        [Route("/api/vehicle/upgraderecords/update")]
+        [Consumes("application/json")]
+        public IActionResult UpdateUpgradeRecordJson([FromBody] GenericRecordExportModel input) => UpdateUpgradeRecord(input);
         [HttpPut]
         [Route("/api/vehicle/upgraderecords/update")]
         public IActionResult UpdateUpgradeRecord(GenericRecordExportModel input)
@@ -511,6 +538,11 @@ namespace CarCareTracker.Controllers
         [TypeFilter(typeof(CollaboratorFilter))]
         [HttpPost]
         [Route("/api/vehicle/taxrecords/add")]
+        [Consumes("application/json")]
+        public IActionResult AddTaxRecordJson(int vehicleId, [FromBody] TaxRecordExportModel input) => AddTaxRecord(vehicleId, input);
+        [TypeFilter(typeof(CollaboratorFilter))]
+        [HttpPost]
+        [Route("/api/vehicle/taxrecords/add")]
         public IActionResult AddTaxRecord(int vehicleId, TaxRecordExportModel input)
         {
             if (vehicleId == default)
@@ -548,6 +580,10 @@ namespace CarCareTracker.Controllers
                 return Json(OperationResponse.Failed(ex.Message));
             }
         }
+        [HttpPut]
+        [Route("/api/vehicle/taxrecords/update")]
+        [Consumes("application/json")]
+        public IActionResult UpdateTaxRecordJson([FromBody] TaxRecordExportModel input) => UpdateTaxRecord(input);
         [HttpPut]
         [Route("/api/vehicle/taxrecords/update")]
         public IActionResult UpdateTaxRecord(TaxRecordExportModel input)
@@ -633,6 +669,11 @@ namespace CarCareTracker.Controllers
         [TypeFilter(typeof(CollaboratorFilter))]
         [HttpPost]
         [Route("/api/vehicle/odometerrecords/add")]
+        [Consumes("application/json")]
+        public IActionResult AddOdometerRecordJson(int vehicleId, [FromBody] OdometerRecordExportModel input) => AddOdometerRecord(vehicleId, input);
+        [TypeFilter(typeof(CollaboratorFilter))]
+        [HttpPost]
+        [Route("/api/vehicle/odometerrecords/add")]
         public IActionResult AddOdometerRecord(int vehicleId, OdometerRecordExportModel input)
         {
             if (vehicleId == default)
@@ -667,6 +708,10 @@ namespace CarCareTracker.Controllers
                 return Json(OperationResponse.Failed(ex.Message));
             }
         }
+        [HttpPut]
+        [Route("/api/vehicle/odometerrecords/update")]
+        [Consumes("application/json")]
+        public IActionResult UpdateOdometerRecordJson([FromBody] OdometerRecordExportModel input) => UpdateOdometerRecord(input);
         [HttpPut]
         [Route("/api/vehicle/odometerrecords/update")]
         public IActionResult UpdateOdometerRecord(OdometerRecordExportModel input)
@@ -745,6 +790,11 @@ namespace CarCareTracker.Controllers
         [TypeFilter(typeof(CollaboratorFilter))]
         [HttpPost]
         [Route("/api/vehicle/gasrecords/add")]
+        [Consumes("application/json")]
+        public IActionResult AddGasRecordJson(int vehicleId, [FromBody] GasRecordExportModel input) => AddGasRecord(vehicleId, input);
+        [TypeFilter(typeof(CollaboratorFilter))]
+        [HttpPost]
+        [Route("/api/vehicle/gasrecords/add")]
         public IActionResult AddGasRecord(int vehicleId, GasRecordExportModel input)
         {
             if (vehicleId == default)
@@ -799,6 +849,10 @@ namespace CarCareTracker.Controllers
                 return Json(OperationResponse.Failed(ex.Message));
             }
         }
+        [HttpPut]
+        [Route("/api/vehicle/gasrecords/update")]
+        [Consumes("application/json")]
+        public IActionResult UpdateGasRecordJson([FromBody] GasRecordExportModel input) => UpdateGasRecord(input);
         [HttpPut]
         [Route("/api/vehicle/gasrecords/update")]
         public IActionResult UpdateGasRecord(GasRecordExportModel input)

--- a/Controllers/VehicleController.cs
+++ b/Controllers/VehicleController.cs
@@ -95,7 +95,6 @@ namespace CarCareTracker.Controllers
         public IActionResult Index(int vehicleId)
         {
             var data = _dataAccess.GetVehicleById(vehicleId);
-            UpdateRecurringTaxes(vehicleId);
             return View(data);
         }
         [HttpGet]

--- a/Helper/StaticHelper.cs
+++ b/Helper/StaticHelper.cs
@@ -9,7 +9,7 @@ namespace CarCareTracker.Helper
     /// </summary>
     public static class StaticHelper
     {
-        public const string VersionNumber = "1.4.1";
+        public const string VersionNumber = "1.4.2";
         public const string DbName = "data/cartracker.db";
         public const string UserConfigPath = "config/userConfig.json";
         public const string AdditionalWidgetsPath = "data/widgets.html";

--- a/Logic/VehicleLogic.cs
+++ b/Logic/VehicleLogic.cs
@@ -350,14 +350,21 @@ namespace CarCareTracker.Logic
                     var originalDate = recurringFee.Date;
                     while (isOutdated)
                     {
-                        var nextDate = originalDate.AddMonths(monthInterval * monthMultiplier);
-                        monthMultiplier++;
-                        var nextnextDate = originalDate.AddMonths(monthInterval * monthMultiplier);
-                        recurringFee.Date = nextDate;
-                        recurringFee.Id = default; //new record
-                        recurringFee.IsRecurring = DateTime.Now <= nextnextDate;
-                        _taxRecordDataAccess.SaveTaxRecordToVehicle(recurringFee);
-                        isOutdated = !recurringFee.IsRecurring;
+                        try
+                        {
+                            var nextDate = originalDate.AddMonths(monthInterval * monthMultiplier);
+                            monthMultiplier++;
+                            var nextnextDate = originalDate.AddMonths(monthInterval * monthMultiplier);
+                            recurringFee.Date = nextDate;
+                            recurringFee.Id = default; //new record
+                            recurringFee.IsRecurring = DateTime.Now <= nextnextDate;
+                            _taxRecordDataAccess.SaveTaxRecordToVehicle(recurringFee);
+                            isOutdated = !recurringFee.IsRecurring;
+                        }
+                        catch (Exception)
+                        {
+                            isOutdated = false; //break out of loop if something broke.
+                        }
                     }
                 }
             }

--- a/Models/API/TypeConverter.cs
+++ b/Models/API/TypeConverter.cs
@@ -1,0 +1,96 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CarCareTracker.Models
+{
+    class FromDateOptional: JsonConverter<string>
+    {
+        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var tokenType = reader.TokenType;
+            if (tokenType == JsonTokenType.String)
+            {
+                return reader.GetString();
+            }
+            else if (tokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out int intInput))
+                {
+                    return DateTimeOffset.FromUnixTimeSeconds(intInput).Date.ToShortDateString();
+                }
+            }
+            return reader.GetString();
+        }
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
+    }
+    class FromDecimalOptional : JsonConverter<string>
+    {
+        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var tokenType = reader.TokenType;
+            if (tokenType == JsonTokenType.String)
+            {
+                return reader.GetString();
+            }
+            else if (tokenType == JsonTokenType.Number) {
+                if (reader.TryGetDecimal(out decimal decimalInput))
+                {
+                    return decimalInput.ToString();
+                }
+            }
+            return reader.GetString();
+        }
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
+    }
+    class FromIntOptional : JsonConverter<string>
+    {
+        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var tokenType = reader.TokenType;
+            if (tokenType == JsonTokenType.String)
+            {
+                return reader.GetString();
+            }
+            else if (tokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out int intInput))
+                {
+                    return intInput.ToString();
+                }
+            }
+            return reader.GetString();
+        }
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
+    }
+    class FromBoolOptional : JsonConverter<string>
+    {
+        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var tokenType = reader.TokenType;
+            switch (tokenType)
+            {
+                case JsonTokenType.String: 
+                    return reader.GetString();
+                case JsonTokenType.True:
+                    return "True";
+                case JsonTokenType.False:
+                    return "False";
+                default:
+                    return reader.GetString();
+            }
+        }
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
+    }
+}

--- a/Models/Shared/ImportModel.cs
+++ b/Models/Shared/ImportModel.cs
@@ -1,4 +1,6 @@
-﻿namespace CarCareTracker.Models
+﻿using System.Text.Json.Serialization;
+
+namespace CarCareTracker.Models
 {
     /// <summary>
     /// Import model used for importing records via CSV.
@@ -46,10 +48,13 @@
     public class GenericRecordExportModel
     {
         public string Id { get; set; }
+        [JsonConverter(typeof(FromDateOptional))]
         public string Date { get; set; }
+        [JsonConverter(typeof(FromIntOptional))]
         public string Odometer { get; set; }
         public string Description { get; set; }
         public string Notes { get; set; }
+        [JsonConverter(typeof(FromDecimalOptional))]
         public string Cost { get; set; }
         public string Tags { get; set; }
         public List<ExtraField> ExtraFields { get; set; }
@@ -57,8 +62,11 @@
     public class OdometerRecordExportModel
     {
         public string Id { get; set; }
+        [JsonConverter(typeof(FromDateOptional))]
         public string Date { get; set; }
+        [JsonConverter(typeof(FromIntOptional))]
         public string InitialOdometer { get; set; }
+        [JsonConverter(typeof(FromIntOptional))]
         public string Odometer { get; set; }
         public string Notes { get; set; }
         public string Tags { get; set; }
@@ -67,9 +75,11 @@
     public class TaxRecordExportModel
     {
         public string Id { get; set; }
+        [JsonConverter(typeof(FromDateOptional))]
         public string Date { get; set; }
         public string Description { get; set; }
         public string Notes { get; set; }
+        [JsonConverter(typeof(FromDecimalOptional))]
         public string Cost { get; set; }
         public string Tags { get; set; }
         public List<ExtraField> ExtraFields { get; set; }
@@ -77,12 +87,18 @@
     public class GasRecordExportModel
     {
         public string Id { get; set; }
+        [JsonConverter(typeof(FromDateOptional))]
         public string Date { get; set; }
+        [JsonConverter(typeof(FromIntOptional))]
         public string Odometer { get; set; }
+        [JsonConverter(typeof(FromDecimalOptional))]
         public string FuelConsumed { get; set; }
+        [JsonConverter(typeof(FromDecimalOptional))]
         public string Cost { get; set; }
         public string FuelEconomy { get; set; }
+        [JsonConverter(typeof(FromBoolOptional))]
         public string IsFillToFull { get; set; }
+        [JsonConverter(typeof(FromBoolOptional))]
         public string MissedFuelUp { get; set; }
         public string Notes { get; set; }
         public string Tags { get; set; }

--- a/Models/Shared/ImportModel.cs
+++ b/Models/Shared/ImportModel.cs
@@ -45,6 +45,7 @@
     }
     public class GenericRecordExportModel
     {
+        public string Id { get; set; }
         public string Date { get; set; }
         public string Odometer { get; set; }
         public string Description { get; set; }
@@ -55,6 +56,7 @@
     }
     public class OdometerRecordExportModel
     {
+        public string Id { get; set; }
         public string Date { get; set; }
         public string InitialOdometer { get; set; }
         public string Odometer { get; set; }
@@ -64,6 +66,7 @@
     }
     public class TaxRecordExportModel
     {
+        public string Id { get; set; }
         public string Date { get; set; }
         public string Description { get; set; }
         public string Notes { get; set; }
@@ -73,6 +76,7 @@
     }
     public class GasRecordExportModel
     {
+        public string Id { get; set; }
         public string Date { get; set; }
         public string Odometer { get; set; }
         public string FuelConsumed { get; set; }

--- a/Views/API/Index.cshtml
+++ b/Views/API/Index.cshtml
@@ -28,7 +28,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicles</code>
@@ -42,7 +42,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/info</code>
@@ -56,7 +56,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/adjustedodometer</code>
@@ -72,7 +72,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/odometerrecords</code>
@@ -86,7 +86,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/odometerrecords/latest</code>
@@ -100,7 +100,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        POST
+        <span class="badge bg-primary">POST</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/odometerrecords/add</code>
@@ -123,7 +123,30 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge text-bg-warning">PUT</span>
+    </div>
+    <div class="col-5 copyable">
+        <code>/api/vehicle/odometerrecords/update</code>
+    </div>
+    <div class="col-3">
+        Updates Odometer Record
+    </div>
+    <div class="col-3">
+        Id - Id of Odometer Record
+        <br />
+        Body(form-data): {<br />
+        date - Date to be entered<br />
+        initialOdometer - Initial Odometer reading<br />
+        odometer - Odometer reading<br />
+        notes - notes(optional)<br />
+        tags - tags separated by space(optional)<br />
+        extrafields - <a class="link-body-emphasis link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover reminder-calendar-item" onclick="showExtraFieldsInfo()">extrafields(optional)</a><br />
+        }
+    </div>
+</div>
+<div class="row api-method">
+    <div class="col-1">
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/servicerecords</code>
@@ -137,7 +160,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        POST
+        <span class="badge bg-primary">POST</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/servicerecords/add</code>
@@ -161,7 +184,31 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge text-bg-warning">PUT</span>
+    </div>
+    <div class="col-5 copyable">
+        <code>/api/vehicle/servicerecords/update</code>
+    </div>
+    <div class="col-3">
+        Updates Service Record
+    </div>
+    <div class="col-3">
+        Id - Id of Service Record
+        <br />
+        Body(form-data): {<br />
+        date - Date to be entered<br />
+        odometer - Odometer reading<br />
+        description - Description<br />
+        cost - Cost<br />
+        notes - notes(optional)<br />
+        tags - tags separated by space(optional)<br />
+        extrafields - <a class="link-body-emphasis link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover reminder-calendar-item" onclick="showExtraFieldsInfo()">extrafields(optional)</a><br />
+        }
+    </div>
+</div>
+<div class="row api-method">
+    <div class="col-1">
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/repairrecords</code>
@@ -175,7 +222,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        POST
+        <span class="badge bg-primary">POST</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/repairrecords/add</code>
@@ -199,7 +246,31 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge text-bg-warning">PUT</span>
+    </div>
+    <div class="col-5 copyable">
+        <code>/api/vehicle/repairrecords/update</code>
+    </div>
+    <div class="col-3">
+        Updates Repair Record
+    </div>
+    <div class="col-3">
+        Id - Id of Repair Record
+        <br />
+        Body(form-data): {<br />
+        date - Date to be entered<br />
+        odometer - Odometer reading<br />
+        description - Description<br />
+        cost - Cost<br />
+        notes - notes(optional)<br />
+        tags - tags separated by space(optional)<br />
+        extrafields - <a class="link-body-emphasis link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover reminder-calendar-item" onclick="showExtraFieldsInfo()">extrafields(optional)</a><br />
+        }
+    </div>
+</div>
+<div class="row api-method">
+    <div class="col-1">
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/upgraderecords</code>
@@ -213,7 +284,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        POST
+        <span class="badge bg-primary">POST</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/upgraderecords/add</code>
@@ -237,7 +308,31 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge text-bg-warning">PUT</span>
+    </div>
+    <div class="col-5 copyable">
+        <code>/api/vehicle/upgraderecords/update</code>
+    </div>
+    <div class="col-3">
+        Updates Upgrade Record
+    </div>
+    <div class="col-3">
+        Id - Id of Upgrade Record
+        <br />
+        Body(form-data): {<br />
+        date - Date to be entered<br />
+        odometer - Odometer reading<br />
+        description - Description<br />
+        cost - Cost<br />
+        notes - notes(optional)<br />
+        tags - tags separated by space(optional)<br />
+        extrafields - <a class="link-body-emphasis link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover reminder-calendar-item" onclick="showExtraFieldsInfo()">extrafields(optional)</a><br />
+        }
+    </div>
+</div>
+<div class="row api-method">
+    <div class="col-1">
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/taxrecords</code>
@@ -251,7 +346,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        POST
+        <span class="badge bg-primary">POST</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/taxrecords/add</code>
@@ -274,7 +369,30 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge text-bg-warning">PUT</span>
+    </div>
+    <div class="col-5 copyable">
+        <code>/api/vehicle/taxrecords/update</code>
+    </div>
+    <div class="col-3">
+        Updates Tax Record
+    </div>
+    <div class="col-3">
+        Id - Id of Tax Record
+        <br />
+        Body(form-data): {<br />
+        date - Date to be entered<br />
+        description - Description<br />
+        cost - Cost<br />
+        notes - notes(optional)<br />
+        tags - tags separated by space(optional)<br />
+        extrafields - <a class="link-body-emphasis link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover reminder-calendar-item" onclick="showExtraFieldsInfo()">extrafields(optional)</a><br />
+        }
+    </div>
+</div>
+<div class="row api-method">
+    <div class="col-1">
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/gasrecords</code>
@@ -292,7 +410,7 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        POST
+        <span class="badge bg-primary">POST</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/gasrecords/add</code>
@@ -318,7 +436,33 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
-        GET
+        <span class="badge text-bg-warning">PUT</span>
+    </div>
+    <div class="col-5 copyable">
+        <code>/api/vehicle/gasrecords/update</code>
+    </div>
+    <div class="col-3">
+        Updates Gas Record
+    </div>
+    <div class="col-3">
+        Id - Id of Gas Record
+        <br />
+        Body(form-data): {<br />
+        date - Date to be entered<br />
+        odometer - Odometer reading<br />
+        fuelConsumed - Fuel Consumed<br />
+        cost - Cost<br />
+        isFillToFull(bool) - Filled To Full<br />
+        missedFuelUp(bool) - Missed Fuel Up<br />
+        notes - notes(optional)<br />
+        tags - tags separated by space(optional)<br />
+        extrafields - <a class="link-body-emphasis link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover reminder-calendar-item" onclick="showExtraFieldsInfo()">extrafields(optional)</a><br />
+        }
+    </div>
+</div>
+<div class="row api-method">
+    <div class="col-1">
+        <span class="badge bg-success">GET</span>
     </div>
     <div class="col-5 copyable">
         <code>/api/vehicle/reminders</code>
@@ -334,7 +478,7 @@
 {
     <div class="row api-method">
         <div class="col-1">
-            GET
+            <span class="badge bg-success">GET</span>
         </div>
         <div class="col-5 copyable">
             <code>/api/vehicle/reminders/send</code>
@@ -349,7 +493,7 @@
     </div>
     <div class="row api-method">
         <div class="col-1">
-            GET
+            <span class="badge bg-success">GET</span>
         </div>
         <div class="col-5 copyable">
             <code>/api/makebackup</code>
@@ -363,7 +507,7 @@
     </div>
     <div class="row api-method">
         <div class="col-1">
-            GET
+            <span class="badge bg-success">GET</span>
         </div>
         <div class="col-5 copyable">
             <code>/api/cleanup</code>

--- a/Views/Vehicle/Index.cshtml
+++ b/Views/Vehicle/Index.cshtml
@@ -173,4 +173,5 @@
         return { tab: "@userConfig.DefaultTab" };
     }
     bindWindowResize();
+    checkRecurringTaxes();
 </script>

--- a/wwwroot/js/taxrecord.js
+++ b/wwwroot/js/taxrecord.js
@@ -179,3 +179,11 @@ function getAndValidateTaxRecordValues() {
         reminderRecordId: recurringReminderRecordId
     }
 }
+
+function checkRecurringTaxes() {
+    $.post('/Vehicle/CheckRecurringTaxRecords', { vehicleId: GetVehicleId().vehicleId },function (data) {
+        if (!data) {
+            errorToast(genericErrorMessage());
+        }
+    })
+}


### PR DESCRIPTION
This PR allows for JSON bodies with rich datatypes to be posted to API methods.

Unlike the current implementation that relies on `form-data` and `x-www-form-urlencoded` JSON requests will allow for cultural invariant inputs(See example below)

```
{
    "date":"10/15/2024",
    "odometer":250000,
    "cost":35.44,
    "fuelConsumed": 12.22,
    "isFillToFull": true,
    "missedFuelUp": false,
    "extraFields": [
        {
            "name": "Gas Station",
            "value": "Maverik"
        }
    ]
}
```

"cost" and "fuelConsumed" fields will take decimal values, note that if passing in decimal values these fields are culturally invariant! If passing in as string e.g.: `"35.44"` then it will be culturally sensitive, if you use a European locale such as de_DE and you wish to pass in a string you will have to pass in `"35,44"`

"odometer" fields will take both an int32 value or a string.

boolean fields such as "isFillToFull" and "missedFuelUp" will accept JSON true/false values and string values: `"True"` / `"False"`

"date" fields will accept the following:

- Culturally sensitive date format e.g.: `"10/15/2024"` or `"15/10/2024"` depending on configured locale, must be string.
- ISO 8601 e.g.: `"2024-10-15"`, must be string.
- Unix TimeStamp in Seconds e.g.: `1733251706`, must be int32