### PR TITLE
Load userConfig.json from the current directory

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -85,7 +85,8 @@ if (!Directory.Exists("config"))
 }
 
 //Additional JsonFile
-builder.Configuration.AddJsonFile(StaticHelper.UserConfigPath, optional: true, reloadOnChange: true);
+var currentDirectory = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(System.IO.Directory.GetCurrentDirectory());
+builder.Configuration.AddJsonFile(currentDirectory, StaticHelper.UserConfigPath, optional: true, reloadOnChange: true);
 
 //Configure Auth
 builder.Services.AddDataProtection();


### PR DESCRIPTION
Previously `config/userConfig.json` was loaded from a location relative to the ContentRoot, but written to a location relative to the current directory.

This meant that the configuration would not be loaded correctly if the current working directory is not the ContentRoot (e.g. if `DOTNET_CONTENTROOT` is set).