### PR TITLE
Document the Calendar API along with support for auth.

### DIFF
--- a/Middleware/Authen.cs
+++ b/Middleware/Authen.cs
@@ -154,6 +154,7 @@ namespace CarCareTracker.Middleware
                 if (value.ToString().ToLower() == "api")
                 {
                     Response.StatusCode = 401;
+                    Response.Headers.Append("WWW-Authenticate", "Basic");
                     return Task.CompletedTask;
                 }
             }

--- a/Views/API/Index.cshtml
+++ b/Views/API/Index.cshtml
@@ -580,6 +580,20 @@
 </div>
 <div class="row api-method">
     <div class="col-1">
+        <span class="badge bg-success">GET</span>
+    </div>
+    <div class="col-5 copyable">
+        <code>/api/calendar</code>
+    </div>
+    <div class="col-3">
+        Returns reminder calendar in ICS format
+    </div>
+    <div class="col-3">
+        No Params
+    </div>
+</div>
+<div class="row api-method">
+    <div class="col-1">
         <span class="badge bg-primary">POST</span>
     </div>
     <div class="col-5 copyable">


### PR DESCRIPTION
Added documentation for the calendar API endpoint.

How to auth:
`https://username:password@lubeloggerdomain/api/calendar`

Note: username and password needs to be URL encoded depending on your OS/Calendar App.

Tested on G Calendar and MacOS Calendar.