### PR TITLE
Show last odometer value as placeholder when creating new fuel record

### DIFF
--- a/Views/Vehicle/_GasModal.cshtml
+++ b/Views/Vehicle/_GasModal.cshtml
@@ -59,6 +59,7 @@
                         <input type="number" inputmode="numeric" id="gasRecordMileage" class="form-control" placeholder="@translator.Translate(userLanguage,"Odometer reading when refueled")" value="@(isNew || Model.GasRecord.Mileage == default ? "" : Model.GasRecord.Mileage)">
                         @if (isNew)
                         {
+                        <script>setLastOdometer();</script>
                             <div class="input-group-text">
                                 <button type="button" class="btn btn-sm btn-primary zero-y-padding" onclick="getLastOdometerReadingAndIncrement('gasRecordMileage')"><i class="bi bi-plus"></i></button>
                             </div>

--- a/wwwroot/js/gasrecord.js
+++ b/wwwroot/js/gasrecord.js
@@ -9,6 +9,17 @@
         }
     });
 }
+
+function setLastOdometer() {
+     $.get(`/Vehicle/GetMaxMileage?vehicleId=${GetVehicleId().vehicleId}`, function (data) {
+        if (isNaN(data)) {
+            return;
+        }
+        $("#gasRecordMileage").attr('placeholder', data);
+        return data;
+     });
+}
+
 function showEditGasRecordModal(gasRecordId, nocache) {
     if (!nocache) {
         var existingContent = $("#gasRecordModalContent").html();


### PR DESCRIPTION
This PR adds a JS function, which sets the last odometer as a placeholder to the odometer input field when creating a new fuel record.
I find myself always clicking the + button to increase the last odometer by 1, so that I have the last odometer record when entring the data. This might PR be quite helpful for some people