### PR TITLE
Add check for email claims.

### DIFF
--- a/Controllers/LoginController.cs
+++ b/Controllers/LoginController.cs
@@ -136,7 +136,15 @@ namespace CarCareTracker.Controllers
                         //validate JWT token
                         var tokenParser = new JwtSecurityTokenHandler();
                         var parsedToken = tokenParser.ReadJwtToken(userJwt);
-                        var userEmailAddress = parsedToken.Claims.First(x => x.Type == "email").Value;
+                        var userEmailAddress = string.Empty;
+                        if (parsedToken.Claims.Any(x => x.Type == "email"))
+                        {
+                            userEmailAddress = parsedToken.Claims.First(x => x.Type == "email").Value;
+                        } else
+                        {
+                            var returnedClaims = parsedToken.Claims.Select(x => x.Type);
+                            _logger.LogError($"OpenID Provider did not provide an email claim, claims returned: {string.Join(",", returnedClaims)}");
+                        }
                         if (!string.IsNullOrWhiteSpace(userEmailAddress))
                         {
                             var userData = _loginLogic.ValidateOpenIDUser(new LoginModel() { EmailAddress = userEmailAddress });


### PR DESCRIPTION
Added check for email claim to prevent exception `Sequence contains no matched elements`  in the situation where certain OIDC providers do not include an email claim when the user does not have an email address.

This error message will also return a list of claims returned by the OIDC provider.