### PR TITLE
Updated _NoteModal.cshtml label to correctly target file input 'noteFiles'

### DIFF
--- a/Views/Vehicle/_NoteModal.cshtml
+++ b/Views/Vehicle/_NoteModal.cshtml
@@ -33,14 +33,14 @@
                     {
                         <div>
                             @await Html.PartialAsync("_UploadedFiles", Model.Files)
-                            <label for="serviceRecordFiles">@translator.Translate(userLanguage, "Upload more documents")</label>
+                            <label for="noteFiles">@translator.Translate(userLanguage, "Upload more documents")</label>
                             <input onChange="uploadVehicleFilesAsync(this)" type="file" multiple accept="@config.GetAllowedFileUploadExtensions()" class="form-control-file" id="noteFiles">
                             <br /><small class="text-body-secondary">@translator.Translate(userLanguage, "Max File Size: 28.6MB")</small>
                         </div>
                     }
                     else
                     {
-                        <label for="serviceRecordFiles">@translator.Translate(userLanguage, "Upload documents(optional)")</label>
+                        <label for="noteFiles">@translator.Translate(userLanguage, "Upload documents(optional)")</label>
                         <input onChange="uploadVehicleFilesAsync(this)" type="file" multiple accept="@config.GetAllowedFileUploadExtensions()" class="form-control-file" id="noteFiles">
                         <br />
                         <small class="text-body-secondary">@translator.Translate(userLanguage, "Max File Size: 28.6MB")</small>


### PR DESCRIPTION
Minor housekeeping PR - fixed the label attribute in _NoteModal.cshtml to correctly target the noteFiles input consistent with other views.