### PR TITLE
feat: disable/enable case sensitive-search

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  unit-tests:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        dotnet-version: ['8.0.x']
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ matrix.dotnet-version }}
+        
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+          
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build solution
+      run: dotnet build --no-restore --configuration Release
+      
+    - name: Run tests
+      run: dotnet test --no-build --configuration Release --logger:"console;verbosity=detailed"

--- a/CarCareTracker.csproj
+++ b/CarCareTracker.csproj
@@ -11,6 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="Tests/**" />
+    <EmbeddedResource Remove="Tests/**" />
+    <None Remove="Tests/**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="LiteDB" Version="5.0.17" />
     <PackageReference Include="MailKit" Version="4.13.0" />

--- a/CarCareTracker.sln
+++ b/CarCareTracker.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CarCareTracker", "CarCareTracker.csproj", "{0DB85611-6555-4127-A66E-DADD25A16526}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CarCareTracker.Tests", "Tests\CarCareTracker.Tests.csproj", "{7F630D7C-4397-4CF8-BD96-065796AB107C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{0DB85611-6555-4127-A66E-DADD25A16526}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0DB85611-6555-4127-A66E-DADD25A16526}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0DB85611-6555-4127-A66E-DADD25A16526}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F630D7C-4397-4CF8-BD96-065796AB107C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F630D7C-4397-4CF8-BD96-065796AB107C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F630D7C-4397-4CF8-BD96-065796AB107C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F630D7C-4397-4CF8-BD96-065796AB107C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -6,6 +6,7 @@ using CarCareTracker.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
+using System.Text.Json;
 
 namespace CarCareTracker.Controllers
 {
@@ -2015,6 +2016,250 @@ namespace CarCareTracker.Controllers
             }
             return Json(jsonResponse);
         }
+        [TypeFilter(typeof(CollaboratorFilter))]
+        [HttpPost]
+        [Route("/api/vehicle/searchrecords")]
+        public IActionResult SearchRecords(int vehicleId, string searchQuery, bool? caseSensitive = null)
+        {
+            List<SearchResult> searchResults = new List<SearchResult>();
+            if (string.IsNullOrWhiteSpace(searchQuery))
+            {
+                return Json(searchResults);
+            }
+            
+            // Use user's configuration if caseSensitive parameter is not provided
+            bool useCaseSensitive = caseSensitive ?? _config.GetUserConfig(User).UseDefaultCaseSensitiveSearch;
+            
+            if (!useCaseSensitive)
+            {
+                searchQuery = searchQuery.ToLower();
+            }
+            foreach (ImportMode visibleTab in _config.GetUserConfig(User).VisibleTabs)
+            {
+                switch (visibleTab)
+                {
+                    case ImportMode.ServiceRecord:
+                        {
+                            var results = _serviceRecordDataAccess.GetServiceRecordsByVehicleId(vehicleId);
+                            if (useCaseSensitive)
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.ServiceRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                            } 
+                            else
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).ToLower().Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.ServiceRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                            }
+                        }
+                        break;
+                    case ImportMode.RepairRecord:
+                        {
+                            var results = _collisionRecordDataAccess.GetCollisionRecordsByVehicleId(vehicleId);
+                            if (useCaseSensitive)
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.RepairRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                            } 
+                            else
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).ToLower().Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.RepairRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                            }
+                        }
+                        break;
+                    case ImportMode.UpgradeRecord:
+                        {
+                            var results = _upgradeRecordDataAccess.GetUpgradeRecordsByVehicleId(vehicleId);
+                            if (useCaseSensitive)
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.UpgradeRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                            } 
+                            else
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).ToLower().Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.UpgradeRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                            }
+                        }
+                        break;
+                    case ImportMode.TaxRecord:
+                        {
+                            var results = _taxRecordDataAccess.GetTaxRecordsByVehicleId(vehicleId);
+                            if (useCaseSensitive)
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.TaxRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                            }
+                            else
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).ToLower().Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.TaxRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                            }
+                        }
+                        break;
+                    case ImportMode.SupplyRecord:
+                        {
+                            var results = _supplyRecordDataAccess.GetSupplyRecordsByVehicleId(vehicleId);
+                            if (useCaseSensitive)
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.SupplyRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                            } 
+                            else
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).ToLower().Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.SupplyRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                            }
+                        }
+                        break;
+                    case ImportMode.PlanRecord:
+                        {
+                            var results = _planRecordDataAccess.GetPlanRecordsByVehicleId(vehicleId);
+                            if (useCaseSensitive)
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.PlanRecord, Description = $"{x.DateCreated.ToShortDateString()} - {x.Description}" }));
+                            } 
+                            else
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).ToLower().Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.PlanRecord, Description = $"{x.DateCreated.ToShortDateString()} - {x.Description}" }));
+                            }
+                        }
+                        break;
+                    case ImportMode.OdometerRecord:
+                        {
+                            var results = _odometerRecordDataAccess.GetOdometerRecordsByVehicleId(vehicleId);
+                            if (useCaseSensitive)
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.OdometerRecord, Description = $"{x.Date.ToShortDateString()} - {x.Mileage}" }));
+                            } 
+                            else
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).ToLower().Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.OdometerRecord, Description = $"{x.Date.ToShortDateString()} - {x.Mileage}" }));
+                            }
+                        }
+                        break;
+                    case ImportMode.GasRecord:
+                        {
+                            var results = _gasRecordDataAccess.GetGasRecordsByVehicleId(vehicleId);
+                            if (useCaseSensitive)
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.GasRecord, Description = $"{x.Date.ToShortDateString()} - {x.Mileage}" }));
+                            }
+                            else
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).ToLower().Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.GasRecord, Description = $"{x.Date.ToShortDateString()} - {x.Mileage}" }));
+                            }
+                        }
+                        break;
+                    case ImportMode.NoteRecord:
+                        {
+                            var results = _noteDataAccess.GetNotesByVehicleId(vehicleId);
+                            if (useCaseSensitive)
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.NoteRecord, Description = $"{x.Description}" }));
+                            }
+                            else
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).ToLower().Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.NoteRecord, Description = $"{x.Description}" }));
+                            }
+                        }
+                        break;
+                    case ImportMode.ReminderRecord:
+                        {
+                            var results = _reminderRecordDataAccess.GetReminderRecordsByVehicleId(vehicleId);
+                            if (useCaseSensitive)
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.ReminderRecord, Description = $"{x.Description}" }));
+                            }
+                            else
+                            {
+                                searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).ToLower().Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.ReminderRecord, Description = $"{x.Description}" }));
+                            }
+                        }
+                        break;
+                }
+            }
+            return Json(searchResults);
+        }
+        
+        [TypeFilter(typeof(CollaboratorFilter))]
+        [HttpPost]
+        [Route("/api/vehicle/searchrecordsbytags")]
+        public IActionResult SearchRecordsByTags(int vehicleId, string tags, bool? caseSensitive = null)
+        {
+            List<SearchResult> searchResults = new List<SearchResult>();
+            if (string.IsNullOrWhiteSpace(tags))
+            {
+                return Json(searchResults);
+            }
+            
+            // Use user's configuration if caseSensitive parameter is not provided
+            bool useCaseSensitive = caseSensitive ?? _config.GetUserConfig(User).UseDefaultCaseSensitiveSearch;
+            
+            var tagsFilter = tags.Split(' ').Where(t => !string.IsNullOrWhiteSpace(t)).Select(t => useCaseSensitive ? t : t.ToLower()).Distinct();
+            foreach (ImportMode visibleTab in _config.GetUserConfig(User).VisibleTabs)
+            {
+                switch (visibleTab)
+                {
+                    case ImportMode.ServiceRecord:
+                        {
+                            var results = _serviceRecordDataAccess.GetServiceRecordsByVehicleId(vehicleId);
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
+                            searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.ServiceRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                        }
+                        break;
+                    case ImportMode.RepairRecord:
+                        {
+                            var results = _collisionRecordDataAccess.GetCollisionRecordsByVehicleId(vehicleId);
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
+                            searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.RepairRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                        }
+                        break;
+                    case ImportMode.UpgradeRecord:
+                        {
+                            var results = _upgradeRecordDataAccess.GetUpgradeRecordsByVehicleId(vehicleId);
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
+                            searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.UpgradeRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                        }
+                        break;
+                    case ImportMode.TaxRecord:
+                        {
+                            var results = _taxRecordDataAccess.GetTaxRecordsByVehicleId(vehicleId);
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
+                            searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.TaxRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                        }
+                        break;
+                    case ImportMode.SupplyRecord:
+                        {
+                            var results = _supplyRecordDataAccess.GetSupplyRecordsByVehicleId(vehicleId);
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
+                            searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.SupplyRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
+                        }
+                        break;
+                    case ImportMode.OdometerRecord:
+                        {
+                            var results = _odometerRecordDataAccess.GetOdometerRecordsByVehicleId(vehicleId);
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
+                            searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.OdometerRecord, Description = $"{x.Date.ToShortDateString()} - {x.Mileage}" }));
+                        }
+                        break;
+                    case ImportMode.GasRecord:
+                        {
+                            var results = _gasRecordDataAccess.GetGasRecordsByVehicleId(vehicleId);
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
+                            searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.GasRecord, Description = $"{x.Date.ToShortDateString()} - {x.Mileage}" }));
+                        }
+                        break;
+                    case ImportMode.NoteRecord:
+                        {
+                            var results = _noteDataAccess.GetNotesByVehicleId(vehicleId);
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
+                            searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.NoteRecord, Description = $"{x.Description}" }));
+                        }
+                        break;
+                    case ImportMode.ReminderRecord:
+                        {
+                            var results = _reminderRecordDataAccess.GetReminderRecordsByVehicleId(vehicleId);
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
+                            searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.ReminderRecord, Description = $"{x.Description}" }));
+                        }
+                        break;
+                }
+            }
+            return Json(searchResults);
+        }
+        
         [Authorize(Roles = nameof(UserData.IsRootUser))]
         [HttpGet]
         [Route("/api/demo/restore")]

--- a/Controllers/VehicleController.cs
+++ b/Controllers/VehicleController.cs
@@ -210,14 +210,18 @@ namespace CarCareTracker.Controllers
         }
         [HttpPost]
         [TypeFilter(typeof(CollaboratorFilter))]
-        public IActionResult SearchRecords(int vehicleId, string searchQuery, bool caseSensitive)
+        public IActionResult SearchRecords(int vehicleId, string searchQuery, bool? caseSensitive = null)
         {
             List<SearchResult> searchResults = new List<SearchResult>();
             if (string.IsNullOrWhiteSpace(searchQuery))
             {
                 return Json(searchResults);
             }
-            if (!caseSensitive)
+            
+            // Use user's configuration if caseSensitive parameter is not provided
+            bool useCaseSensitive = caseSensitive ?? _config.GetUserConfig(User).UseDefaultCaseSensitiveSearch;
+            
+            if (!useCaseSensitive)
             {
                 searchQuery = searchQuery.ToLower();
             }
@@ -228,7 +232,7 @@ namespace CarCareTracker.Controllers
                     case ImportMode.ServiceRecord:
                         {
                             var results = _serviceRecordDataAccess.GetServiceRecordsByVehicleId(vehicleId);
-                            if (caseSensitive)
+                            if (useCaseSensitive)
                             {
                                 searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.ServiceRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
                             } 
@@ -241,7 +245,7 @@ namespace CarCareTracker.Controllers
                     case ImportMode.RepairRecord:
                         {
                             var results = _collisionRecordDataAccess.GetCollisionRecordsByVehicleId(vehicleId);
-                            if (caseSensitive)
+                            if (useCaseSensitive)
                             {
                                 searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.RepairRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
                             } 
@@ -254,7 +258,7 @@ namespace CarCareTracker.Controllers
                     case ImportMode.UpgradeRecord:
                         {
                             var results = _upgradeRecordDataAccess.GetUpgradeRecordsByVehicleId(vehicleId);
-                            if (caseSensitive)
+                            if (useCaseSensitive)
                             {
                                 searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.UpgradeRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
                             } 
@@ -267,7 +271,7 @@ namespace CarCareTracker.Controllers
                     case ImportMode.TaxRecord:
                         {
                             var results = _taxRecordDataAccess.GetTaxRecordsByVehicleId(vehicleId);
-                            if (caseSensitive)
+                            if (useCaseSensitive)
                             {
                                 searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.TaxRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
                             }
@@ -280,7 +284,7 @@ namespace CarCareTracker.Controllers
                     case ImportMode.SupplyRecord:
                         {
                             var results = _supplyRecordDataAccess.GetSupplyRecordsByVehicleId(vehicleId);
-                            if (caseSensitive)
+                            if (useCaseSensitive)
                             {
                                 searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.SupplyRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
                             } 
@@ -293,7 +297,7 @@ namespace CarCareTracker.Controllers
                     case ImportMode.PlanRecord:
                         {
                             var results = _planRecordDataAccess.GetPlanRecordsByVehicleId(vehicleId);
-                            if (caseSensitive)
+                            if (useCaseSensitive)
                             {
                                 searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.PlanRecord, Description = $"{x.DateCreated.ToShortDateString()} - {x.Description}" }));
                             } 
@@ -306,7 +310,7 @@ namespace CarCareTracker.Controllers
                     case ImportMode.OdometerRecord:
                         {
                             var results = _odometerRecordDataAccess.GetOdometerRecordsByVehicleId(vehicleId);
-                            if (caseSensitive)
+                            if (useCaseSensitive)
                             {
                                 searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.OdometerRecord, Description = $"{x.Date.ToShortDateString()} - {x.Mileage}" }));
                             } 
@@ -319,7 +323,7 @@ namespace CarCareTracker.Controllers
                     case ImportMode.GasRecord:
                         {
                             var results = _gasRecordDataAccess.GetGasRecordsByVehicleId(vehicleId);
-                            if (caseSensitive)
+                            if (useCaseSensitive)
                             {
                                 searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.GasRecord, Description = $"{x.Date.ToShortDateString()} - {x.Mileage}" }));
                             }
@@ -332,7 +336,7 @@ namespace CarCareTracker.Controllers
                     case ImportMode.NoteRecord:
                         {
                             var results = _noteDataAccess.GetNotesByVehicleId(vehicleId);
-                            if (caseSensitive)
+                            if (useCaseSensitive)
                             {
                                 searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.NoteRecord, Description = $"{x.Description}" }));
                             }
@@ -345,7 +349,7 @@ namespace CarCareTracker.Controllers
                     case ImportMode.ReminderRecord:
                         {
                             var results = _reminderRecordDataAccess.GetReminderRecordsByVehicleId(vehicleId);
-                            if (caseSensitive)
+                            if (useCaseSensitive)
                             {
                                 searchResults.AddRange(results.Where(x => JsonSerializer.Serialize(x).Contains(searchQuery)).Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.ReminderRecord, Description = $"{x.Description}" }));
                             }
@@ -361,14 +365,18 @@ namespace CarCareTracker.Controllers
         }
         [HttpPost]
         [TypeFilter(typeof(CollaboratorFilter))]
-        public IActionResult SearchRecordsByTags(int vehicleId, string tags)
+        public IActionResult SearchRecordsByTags(int vehicleId, string tags, bool? caseSensitive = null)
         {
             List<SearchResult> searchResults = new List<SearchResult>();
             if (string.IsNullOrWhiteSpace(tags))
             {
                 return Json(searchResults);
             }
-            var tagsFilter = tags.Split(' ').Distinct();
+            
+            // Use user's configuration if caseSensitive parameter is not provided
+            bool useCaseSensitive = caseSensitive ?? _config.GetUserConfig(User).UseDefaultCaseSensitiveSearch;
+            
+            var tagsFilter = tags.Split(' ').Where(t => !string.IsNullOrWhiteSpace(t)).Select(t => useCaseSensitive ? t : t.ToLower()).Distinct();
             foreach (ImportMode visibleTab in _config.GetUserConfig(User).VisibleTabs)
             {
                 switch (visibleTab)
@@ -376,63 +384,63 @@ namespace CarCareTracker.Controllers
                     case ImportMode.ServiceRecord:
                         {
                             var results = _serviceRecordDataAccess.GetServiceRecordsByVehicleId(vehicleId);
-                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
                             searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.ServiceRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
                         }
                         break;
                     case ImportMode.RepairRecord:
                         {
                             var results = _collisionRecordDataAccess.GetCollisionRecordsByVehicleId(vehicleId);
-                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
                             searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.RepairRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
                         }
                         break;
                     case ImportMode.UpgradeRecord:
                         {
                             var results = _upgradeRecordDataAccess.GetUpgradeRecordsByVehicleId(vehicleId);
-                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
                             searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.UpgradeRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
                         }
                         break;
                     case ImportMode.TaxRecord:
                         {
                             var results = _taxRecordDataAccess.GetTaxRecordsByVehicleId(vehicleId);
-                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
                             searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.TaxRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
                         }
                         break;
                     case ImportMode.SupplyRecord:
                         {
                             var results = _supplyRecordDataAccess.GetSupplyRecordsByVehicleId(vehicleId);
-                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
                             searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.SupplyRecord, Description = $"{x.Date.ToShortDateString()} - {x.Description}" }));
                         }
                         break;
                     case ImportMode.OdometerRecord:
                         {
                             var results = _odometerRecordDataAccess.GetOdometerRecordsByVehicleId(vehicleId);
-                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
                             searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.OdometerRecord, Description = $"{x.Date.ToShortDateString()} - {x.Mileage}" }));
                         }
                         break;
                     case ImportMode.GasRecord:
                         {
                             var results = _gasRecordDataAccess.GetGasRecordsByVehicleId(vehicleId);
-                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
                             searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.GasRecord, Description = $"{x.Date.ToShortDateString()} - {x.Mileage}" }));
                         }
                         break;
                     case ImportMode.NoteRecord:
                         {
                             var results = _noteDataAccess.GetNotesByVehicleId(vehicleId);
-                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
                             searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.NoteRecord, Description = $"{x.Description}" }));
                         }
                         break;
                     case ImportMode.ReminderRecord:
                         {
                             var results = _reminderRecordDataAccess.GetReminderRecordsByVehicleId(vehicleId);
-                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+                            results.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(useCaseSensitive ? y : y.ToLower())));
                             searchResults.AddRange(results.Select(x => new SearchResult { Id = x.Id, RecordType = ImportMode.ReminderRecord, Description = $"{x.Description}" }));
                         }
                         break;

--- a/Helper/ConfigHelper.cs
+++ b/Helper/ConfigHelper.cs
@@ -34,6 +34,7 @@ namespace CarCareTracker.Helper
         bool GetInvariantApi();
         bool GetServerOpenRegistration();
         string GetDefaultReminderEmail();
+        bool GetDefaultCaseSensitiveSearch();
     }
     public class ConfigHelper : IConfigHelper
     {
@@ -116,6 +117,10 @@ namespace CarCareTracker.Helper
         {
             var reminderEmail = CheckString(nameof(ServerConfig.DefaultReminderEmail));
             return reminderEmail;
+        }
+        public bool GetDefaultCaseSensitiveSearch()
+        {
+            return CheckBool(CheckString("LUBELOGGER_DEFAULT_CASE_SENSITIVE_SEARCH"), false);
         }
         public string GetAllowedFileUploadExtensions()
         {
@@ -356,7 +361,8 @@ namespace CarCareTracker.Helper
                 TabOrder = _config.GetSection(nameof(UserConfig.TabOrder)).Get<List<ImportMode>>() ?? new UserConfig().TabOrder,
                 UserColumnPreferences = _config.GetSection(nameof(UserConfig.UserColumnPreferences)).Get<List<UserColumnPreference>>() ?? new List<UserColumnPreference>(),
                 DefaultTab = (ImportMode)int.Parse(CheckString(nameof(UserConfig.DefaultTab), "8")),
-                ShowVehicleThumbnail = CheckBool(CheckString(nameof(UserConfig.ShowVehicleThumbnail)))
+                ShowVehicleThumbnail = CheckBool(CheckString(nameof(UserConfig.ShowVehicleThumbnail))),
+                UseDefaultCaseSensitiveSearch = CheckBool(CheckString(nameof(UserConfig.UseDefaultCaseSensitiveSearch)), GetDefaultCaseSensitiveSearch())
             };
             int userId = 0;
             if (user != null)

--- a/Models/UserConfig.cs
+++ b/Models/UserConfig.cs
@@ -24,6 +24,7 @@
         public bool UseUnitForFuelCost { get; set; }
         public bool ShowCalendar { get; set; }
         public bool ShowVehicleThumbnail { get; set; }
+        public bool UseDefaultCaseSensitiveSearch { get; set; } = false;
         public List<UserColumnPreference> UserColumnPreferences { get; set; } = new List<UserColumnPreference>();
         public string UserNameHash { get; set; }
         public string UserPasswordHash { get; set;}

--- a/Tests/CarCareTracker.Tests.csproj
+++ b/Tests/CarCareTracker.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/CarCareTracker.Tests.csproj
+++ b/Tests/CarCareTracker.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../CarCareTracker.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Controllers/APIControllerTests.cs
+++ b/Tests/Controllers/APIControllerTests.cs
@@ -1,0 +1,511 @@
+using CarCareTracker.Controllers;
+using CarCareTracker.External.Interfaces;
+using CarCareTracker.Helper;
+using CarCareTracker.Logic;
+using CarCareTracker.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace CarCareTracker.Tests.Controllers
+{
+    public class APIControllerTests
+    {
+        private readonly Mock<INoteDataAccess> _mockNoteDataAccess;
+        private readonly Mock<IServiceRecordDataAccess> _mockServiceRecordDataAccess;
+        private readonly Mock<IGasRecordDataAccess> _mockGasRecordDataAccess;
+        private readonly Mock<ICollisionRecordDataAccess> _mockCollisionRecordDataAccess;
+        private readonly Mock<ITaxRecordDataAccess> _mockTaxRecordDataAccess;
+        private readonly Mock<IReminderRecordDataAccess> _mockReminderRecordDataAccess;
+        private readonly Mock<IUpgradeRecordDataAccess> _mockUpgradeRecordDataAccess;
+        private readonly Mock<IOdometerRecordDataAccess> _mockOdometerRecordDataAccess;
+        private readonly Mock<ISupplyRecordDataAccess> _mockSupplyRecordDataAccess;
+        private readonly Mock<IPlanRecordDataAccess> _mockPlanRecordDataAccess;
+        private readonly Mock<IPlanRecordTemplateDataAccess> _mockPlanRecordTemplateDataAccess;
+        private readonly Mock<IUserAccessDataAccess> _mockUserAccessDataAccess;
+        private readonly Mock<IUserRecordDataAccess> _mockUserRecordDataAccess;
+        private readonly Mock<IReminderHelper> _mockReminderHelper;
+        private readonly Mock<IGasHelper> _mockGasHelper;
+        private readonly Mock<IUserLogic> _mockUserLogic;
+        private readonly Mock<IOdometerLogic> _mockOdometerLogic;
+        private readonly Mock<IFileHelper> _mockFileHelper;
+        private readonly Mock<IMailHelper> _mockMailHelper;
+        private readonly Mock<IConfigHelper> _mockConfigHelper;
+        private readonly Mock<IWebHostEnvironment> _mockWebHostEnvironment;
+        private readonly APIController _apiController;
+
+        public APIControllerTests()
+        {
+            var mockVehicleDataAccess = new Mock<IVehicleDataAccess>();
+            _mockNoteDataAccess = new Mock<INoteDataAccess>();
+            _mockServiceRecordDataAccess = new Mock<IServiceRecordDataAccess>();
+            _mockGasRecordDataAccess = new Mock<IGasRecordDataAccess>();
+            _mockCollisionRecordDataAccess = new Mock<ICollisionRecordDataAccess>();
+            _mockTaxRecordDataAccess = new Mock<ITaxRecordDataAccess>();
+            _mockReminderRecordDataAccess = new Mock<IReminderRecordDataAccess>();
+            _mockUpgradeRecordDataAccess = new Mock<IUpgradeRecordDataAccess>();
+            _mockOdometerRecordDataAccess = new Mock<IOdometerRecordDataAccess>();
+            _mockSupplyRecordDataAccess = new Mock<ISupplyRecordDataAccess>();
+            _mockPlanRecordDataAccess = new Mock<IPlanRecordDataAccess>();
+            _mockPlanRecordTemplateDataAccess = new Mock<IPlanRecordTemplateDataAccess>();
+            _mockUserAccessDataAccess = new Mock<IUserAccessDataAccess>();
+            _mockUserRecordDataAccess = new Mock<IUserRecordDataAccess>();
+            _mockReminderHelper = new Mock<IReminderHelper>();
+            _mockGasHelper = new Mock<IGasHelper>();
+            _mockUserLogic = new Mock<IUserLogic>();
+            var mockVehicleLogic = new Mock<IVehicleLogic>();
+            _mockOdometerLogic = new Mock<IOdometerLogic>();
+            _mockFileHelper = new Mock<IFileHelper>();
+            _mockMailHelper = new Mock<IMailHelper>();
+            _mockConfigHelper = new Mock<IConfigHelper>();
+            _mockWebHostEnvironment = new Mock<IWebHostEnvironment>();
+
+            _apiController = new APIController(
+                mockVehicleDataAccess.Object,
+                _mockGasHelper.Object,
+                _mockReminderHelper.Object,
+                _mockNoteDataAccess.Object,
+                _mockServiceRecordDataAccess.Object,
+                _mockGasRecordDataAccess.Object,
+                _mockCollisionRecordDataAccess.Object,
+                _mockTaxRecordDataAccess.Object,
+                _mockReminderRecordDataAccess.Object,
+                _mockUpgradeRecordDataAccess.Object,
+                _mockOdometerRecordDataAccess.Object,
+                _mockSupplyRecordDataAccess.Object,
+                _mockPlanRecordDataAccess.Object,
+                _mockPlanRecordTemplateDataAccess.Object,
+                _mockUserAccessDataAccess.Object,
+                _mockUserRecordDataAccess.Object,
+                _mockMailHelper.Object,
+                _mockFileHelper.Object,
+                _mockConfigHelper.Object,
+                _mockUserLogic.Object,
+                mockVehicleLogic.Object,
+                _mockOdometerLogic.Object,
+                _mockWebHostEnvironment.Object
+            );
+
+            // Setup controller context with authenticated user
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "1"),
+                new Claim(ClaimTypes.Name, "testuser")
+            }, "test"));
+
+            _apiController.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = user
+                }
+            };
+        }
+
+        private readonly UserConfig _testUserConfig = new UserConfig
+        {
+            UseDefaultCaseSensitiveSearch = false, // Default to case insensitive
+            VisibleTabs = new List<ImportMode> { ImportMode.ServiceRecord, ImportMode.RepairRecord, ImportMode.GasRecord }
+        };
+
+        [Fact]
+        public void SearchRecords_CaseSensitiveTrue_ExactMatch()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var searchQuery = "Oil";
+            var serviceRecords = new List<ServiceRecord>
+            {
+                new ServiceRecord { Id = 1, Description = "Oil Change", Date = DateTime.Now },
+                new ServiceRecord { Id = 2, Description = "oil filter", Date = DateTime.Now }
+            };
+
+            _mockServiceRecordDataAccess.Setup(x => x.GetServiceRecordsByVehicleId(vehicleId))
+                .Returns(serviceRecords);
+            
+            // Setup empty collections for other record types to prevent null reference exceptions
+            _mockGasRecordDataAccess.Setup(x => x.GetGasRecordsByVehicleId(vehicleId)).Returns(new List<GasRecord>());
+            _mockCollisionRecordDataAccess.Setup(x => x.GetCollisionRecordsByVehicleId(vehicleId)).Returns(new List<CollisionRecord>());
+            _mockUpgradeRecordDataAccess.Setup(x => x.GetUpgradeRecordsByVehicleId(vehicleId)).Returns(new List<UpgradeRecord>());
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(new List<TaxRecord>());
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordsByVehicleId(vehicleId)).Returns(new List<SupplyRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(new List<OdometerRecord>());
+            _mockNoteDataAccess.Setup(x => x.GetNotesByVehicleId(vehicleId)).Returns(new List<Note>());
+            
+            _testUserConfig.UseDefaultCaseSensitiveSearch = false;
+            _mockConfigHelper.Setup(x => x.GetUserConfig(It.IsAny<ClaimsPrincipal>())).Returns(_testUserConfig);
+
+            // Act - explicitly set case sensitive to true
+            var result = _apiController.SearchRecords(vehicleId, searchQuery, caseSensitive: true);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            
+            // Should only find "Oil Change" (exact case match), not "oil filter"
+            Assert.Single(model);
+            Assert.Equal(1, model.First().Id);
+        }
+
+        [Fact]
+        public void SearchRecords_CaseSensitiveFalse_CaseInsensitiveMatch()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var searchQuery = "OIL";
+            var serviceRecords = new List<ServiceRecord>
+            {
+                new ServiceRecord { Id = 1, Description = "Oil Change", Date = DateTime.Now },
+                new ServiceRecord { Id = 2, Description = "oil filter", Date = DateTime.Now },
+                new ServiceRecord { Id = 3, Description = "Brake Service", Date = DateTime.Now }
+            };
+
+            _mockServiceRecordDataAccess.Setup(x => x.GetServiceRecordsByVehicleId(vehicleId))
+                .Returns(serviceRecords);
+            
+            // Setup empty collections for other record types to prevent null reference exceptions
+            _mockGasRecordDataAccess.Setup(x => x.GetGasRecordsByVehicleId(vehicleId)).Returns(new List<GasRecord>());
+            _mockCollisionRecordDataAccess.Setup(x => x.GetCollisionRecordsByVehicleId(vehicleId)).Returns(new List<CollisionRecord>());
+            _mockUpgradeRecordDataAccess.Setup(x => x.GetUpgradeRecordsByVehicleId(vehicleId)).Returns(new List<UpgradeRecord>());
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(new List<TaxRecord>());
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordsByVehicleId(vehicleId)).Returns(new List<SupplyRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(new List<OdometerRecord>());
+            _mockNoteDataAccess.Setup(x => x.GetNotesByVehicleId(vehicleId)).Returns(new List<Note>());
+            
+            _testUserConfig.UseDefaultCaseSensitiveSearch = false;
+            _mockConfigHelper.Setup(x => x.GetUserConfig(It.IsAny<ClaimsPrincipal>())).Returns(_testUserConfig);
+
+            // Act - explicitly set case sensitive to false
+            var result = _apiController.SearchRecords(vehicleId, searchQuery, caseSensitive: false);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            
+            // Should find both "Oil Change" and "oil filter" (case insensitive)
+            Assert.Equal(2, model.Count);
+            Assert.Contains(model, x => x.Id == 1);
+            Assert.Contains(model, x => x.Id == 2);
+        }
+
+        [Fact]
+        public void SearchRecords_NullCaseSensitive_UsesUserConfig()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var searchQuery = "OIL";
+            var serviceRecords = new List<ServiceRecord>
+            {
+                new ServiceRecord { Id = 1, Description = "Oil Change", Date = DateTime.Now },
+                new ServiceRecord { Id = 2, Description = "oil filter", Date = DateTime.Now }
+            };
+
+            _mockServiceRecordDataAccess.Setup(x => x.GetServiceRecordsByVehicleId(vehicleId))
+                .Returns(serviceRecords);
+            
+            // Setup empty collections for other record types to prevent null reference exceptions
+            _mockGasRecordDataAccess.Setup(x => x.GetGasRecordsByVehicleId(vehicleId)).Returns(new List<GasRecord>());
+            _mockCollisionRecordDataAccess.Setup(x => x.GetCollisionRecordsByVehicleId(vehicleId)).Returns(new List<CollisionRecord>());
+            _mockUpgradeRecordDataAccess.Setup(x => x.GetUpgradeRecordsByVehicleId(vehicleId)).Returns(new List<UpgradeRecord>());
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(new List<TaxRecord>());
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordsByVehicleId(vehicleId)).Returns(new List<SupplyRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(new List<OdometerRecord>());
+            _mockNoteDataAccess.Setup(x => x.GetNotesByVehicleId(vehicleId)).Returns(new List<Note>());
+
+            // User config is set to case insensitive (false)
+            _testUserConfig.UseDefaultCaseSensitiveSearch = false;
+            _mockConfigHelper.Setup(x => x.GetUserConfig(It.IsAny<ClaimsPrincipal>())).Returns(_testUserConfig);
+
+            // Act - don't provide caseSensitive parameter, should use user config
+            var result = _apiController.SearchRecords(vehicleId, searchQuery, caseSensitive: null);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            
+            // Should find both records because user config is case insensitive
+            Assert.Equal(2, model.Count);
+        }
+
+        [Fact]
+        public void SearchRecords_NullCaseSensitiveWithUserConfigCaseSensitive_UsesUserConfig()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var searchQuery = "Oil";
+            var serviceRecords = new List<ServiceRecord>
+            {
+                new ServiceRecord { Id = 1, Description = "Oil Change", Date = DateTime.Now },
+                new ServiceRecord { Id = 2, Description = "oil filter", Date = DateTime.Now }
+            };
+
+            _mockServiceRecordDataAccess.Setup(x => x.GetServiceRecordsByVehicleId(vehicleId))
+                .Returns(serviceRecords);
+            
+            // Setup empty collections for other record types to prevent null reference exceptions
+            _mockGasRecordDataAccess.Setup(x => x.GetGasRecordsByVehicleId(vehicleId)).Returns(new List<GasRecord>());
+            _mockCollisionRecordDataAccess.Setup(x => x.GetCollisionRecordsByVehicleId(vehicleId)).Returns(new List<CollisionRecord>());
+            _mockUpgradeRecordDataAccess.Setup(x => x.GetUpgradeRecordsByVehicleId(vehicleId)).Returns(new List<UpgradeRecord>());
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(new List<TaxRecord>());
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordsByVehicleId(vehicleId)).Returns(new List<SupplyRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(new List<OdometerRecord>());
+            _mockNoteDataAccess.Setup(x => x.GetNotesByVehicleId(vehicleId)).Returns(new List<Note>());
+
+            // Set user config to case sensitive (true)
+            _testUserConfig.UseDefaultCaseSensitiveSearch = true;
+            _mockConfigHelper.Setup(x => x.GetUserConfig(It.IsAny<ClaimsPrincipal>())).Returns(_testUserConfig);
+
+            // Act - don't provide caseSensitive parameter, should use user config
+            var result = _apiController.SearchRecords(vehicleId, searchQuery, caseSensitive: null);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            
+            // Should only find "Oil Change" because user config is case sensitive
+            Assert.Single(model);
+            Assert.Equal(1, model.First().Id);
+        }
+
+        [Fact]
+        public void SearchRecordsByTags_CaseSensitiveTrue_ExactTagMatch()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var tags = "Maintenance";
+            var serviceRecords = new List<ServiceRecord>
+            {
+                new ServiceRecord { Id = 1, Description = "Oil Change", Date = DateTime.Now, Tags = new List<string> { "Maintenance", "Oil" } },
+                new ServiceRecord { Id = 2, Description = "Filter Replace", Date = DateTime.Now, Tags = new List<string> { "maintenance", "filter" } }
+            };
+
+            _mockServiceRecordDataAccess.Setup(x => x.GetServiceRecordsByVehicleId(vehicleId))
+                .Returns(serviceRecords);
+            
+            // Setup empty collections for other record types to prevent null reference exceptions
+            _mockGasRecordDataAccess.Setup(x => x.GetGasRecordsByVehicleId(vehicleId)).Returns(new List<GasRecord>());
+            _mockCollisionRecordDataAccess.Setup(x => x.GetCollisionRecordsByVehicleId(vehicleId)).Returns(new List<CollisionRecord>());
+            _mockUpgradeRecordDataAccess.Setup(x => x.GetUpgradeRecordsByVehicleId(vehicleId)).Returns(new List<UpgradeRecord>());
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(new List<TaxRecord>());
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordsByVehicleId(vehicleId)).Returns(new List<SupplyRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(new List<OdometerRecord>());
+            _mockNoteDataAccess.Setup(x => x.GetNotesByVehicleId(vehicleId)).Returns(new List<Note>());
+            
+            _testUserConfig.UseDefaultCaseSensitiveSearch = false;
+            _mockConfigHelper.Setup(x => x.GetUserConfig(It.IsAny<ClaimsPrincipal>())).Returns(_testUserConfig);
+
+            // Act - explicitly set case sensitive to true
+            var result = _apiController.SearchRecordsByTags(vehicleId, tags, caseSensitive: true);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            
+            // Should only find exact case match "Maintenance", not "maintenance"
+            Assert.Single(model);
+            Assert.Equal(1, model.First().Id);
+        }
+
+        [Fact]
+        public void SearchRecordsByTags_CaseSensitiveFalse_CaseInsensitiveTagMatch()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var tags = "MAINTENANCE";
+            var serviceRecords = new List<ServiceRecord>
+            {
+                new ServiceRecord { Id = 1, Description = "Oil Change", Date = DateTime.Now, Tags = new List<string> { "Maintenance", "Oil" } },
+                new ServiceRecord { Id = 2, Description = "Filter Replace", Date = DateTime.Now, Tags = new List<string> { "maintenance", "filter" } },
+                new ServiceRecord { Id = 3, Description = "Brake Service", Date = DateTime.Now, Tags = new List<string> { "brake", "safety" } }
+            };
+
+            _mockServiceRecordDataAccess.Setup(x => x.GetServiceRecordsByVehicleId(vehicleId))
+                .Returns(serviceRecords);
+            
+            // Setup empty collections for other record types to prevent null reference exceptions
+            _mockGasRecordDataAccess.Setup(x => x.GetGasRecordsByVehicleId(vehicleId)).Returns(new List<GasRecord>());
+            _mockCollisionRecordDataAccess.Setup(x => x.GetCollisionRecordsByVehicleId(vehicleId)).Returns(new List<CollisionRecord>());
+            _mockUpgradeRecordDataAccess.Setup(x => x.GetUpgradeRecordsByVehicleId(vehicleId)).Returns(new List<UpgradeRecord>());
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(new List<TaxRecord>());
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordsByVehicleId(vehicleId)).Returns(new List<SupplyRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(new List<OdometerRecord>());
+            _mockNoteDataAccess.Setup(x => x.GetNotesByVehicleId(vehicleId)).Returns(new List<Note>());
+            
+            _testUserConfig.UseDefaultCaseSensitiveSearch = false;
+            _mockConfigHelper.Setup(x => x.GetUserConfig(It.IsAny<ClaimsPrincipal>())).Returns(_testUserConfig);
+
+            // Act - explicitly set case sensitive to false
+            var result = _apiController.SearchRecordsByTags(vehicleId, tags, caseSensitive: false);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            
+            // Should find both "Maintenance" and "maintenance" (case insensitive)
+            Assert.Equal(2, model.Count);
+            Assert.Contains(model, x => x.Id == 1);
+            Assert.Contains(model, x => x.Id == 2);
+        }
+
+        [Fact]
+        public void SearchRecordsByTags_NullCaseSensitive_UsesUserConfig()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var tags = "MAINTENANCE";
+            var serviceRecords = new List<ServiceRecord>
+            {
+                new ServiceRecord { Id = 1, Description = "Oil Change", Date = DateTime.Now, Tags = new List<string> { "Maintenance", "Oil" } },
+                new ServiceRecord { Id = 2, Description = "Filter Replace", Date = DateTime.Now, Tags = new List<string> { "maintenance", "filter" } }
+            };
+
+            _mockServiceRecordDataAccess.Setup(x => x.GetServiceRecordsByVehicleId(vehicleId))
+                .Returns(serviceRecords);
+            
+            // Setup empty collections for other record types to prevent null reference exceptions
+            _mockGasRecordDataAccess.Setup(x => x.GetGasRecordsByVehicleId(vehicleId)).Returns(new List<GasRecord>());
+            _mockCollisionRecordDataAccess.Setup(x => x.GetCollisionRecordsByVehicleId(vehicleId)).Returns(new List<CollisionRecord>());
+            _mockUpgradeRecordDataAccess.Setup(x => x.GetUpgradeRecordsByVehicleId(vehicleId)).Returns(new List<UpgradeRecord>());
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(new List<TaxRecord>());
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordsByVehicleId(vehicleId)).Returns(new List<SupplyRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(new List<OdometerRecord>());
+            _mockNoteDataAccess.Setup(x => x.GetNotesByVehicleId(vehicleId)).Returns(new List<Note>());
+
+            // User config is set to case insensitive (false)
+            _testUserConfig.UseDefaultCaseSensitiveSearch = false;
+            _mockConfigHelper.Setup(x => x.GetUserConfig(It.IsAny<ClaimsPrincipal>())).Returns(_testUserConfig);
+
+            // Act - don't provide caseSensitive parameter, should use user config
+            var result = _apiController.SearchRecordsByTags(vehicleId, tags, caseSensitive: null);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            
+            // Should find both records because user config is case insensitive
+            Assert.Equal(2, model.Count);
+        }
+
+        [Fact]
+        public void SearchRecordsByTags_MultipleTags_HandlesSpacesCorrectly()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var tags = "  maintenance   oil  "; // Extra spaces
+            var serviceRecords = new List<ServiceRecord>
+            {
+                new ServiceRecord { Id = 1, Description = "Oil Change", Date = DateTime.Now, Tags = new List<string> { "maintenance", "oil" } },
+                new ServiceRecord { Id = 2, Description = "Filter Replace", Date = DateTime.Now, Tags = new List<string> { "maintenance", "filter" } },
+                new ServiceRecord { Id = 3, Description = "Oil Filter", Date = DateTime.Now, Tags = new List<string> { "oil", "filter" } }
+            };
+
+            _mockServiceRecordDataAccess.Setup(x => x.GetServiceRecordsByVehicleId(vehicleId))
+                .Returns(serviceRecords);
+            
+            // Setup empty collections for other record types to prevent null reference exceptions
+            _mockGasRecordDataAccess.Setup(x => x.GetGasRecordsByVehicleId(vehicleId)).Returns(new List<GasRecord>());
+            _mockCollisionRecordDataAccess.Setup(x => x.GetCollisionRecordsByVehicleId(vehicleId)).Returns(new List<CollisionRecord>());
+            _mockUpgradeRecordDataAccess.Setup(x => x.GetUpgradeRecordsByVehicleId(vehicleId)).Returns(new List<UpgradeRecord>());
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(new List<TaxRecord>());
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordsByVehicleId(vehicleId)).Returns(new List<SupplyRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(new List<OdometerRecord>());
+            _mockNoteDataAccess.Setup(x => x.GetNotesByVehicleId(vehicleId)).Returns(new List<Note>());
+            
+            _testUserConfig.UseDefaultCaseSensitiveSearch = false;
+            _mockConfigHelper.Setup(x => x.GetUserConfig(It.IsAny<ClaimsPrincipal>())).Returns(_testUserConfig);
+
+            // Act - case insensitive search
+            var result = _apiController.SearchRecordsByTags(vehicleId, tags, caseSensitive: false);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            
+            // Should find records that have either "maintenance" or "oil" tags
+            Assert.Equal(3, model.Count); // All records have at least one matching tag
+        }
+
+        [Fact]
+        public void SearchRecords_EmptySearchQuery_ReturnsEmptyResults()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var searchQuery = "";
+
+            // Act
+            var result = _apiController.SearchRecords(vehicleId, searchQuery);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            Assert.Empty(model);
+        }
+
+        [Fact]
+        public void SearchRecordsByTags_EmptyTags_ReturnsEmptyResults()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var tags = "";
+
+            // Act
+            var result = _apiController.SearchRecordsByTags(vehicleId, tags);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            Assert.Empty(model);
+        }
+
+        [Fact]
+        public void SearchRecords_MultipleRecordTypes_ReturnsResultsFromAllTypes()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var searchQuery = "test";
+            
+            var serviceRecords = new List<ServiceRecord>
+            {
+                new ServiceRecord { Id = 1, Description = "Test Service", Date = DateTime.Now }
+            };
+            
+            var gasRecords = new List<GasRecord>
+            {
+                new GasRecord { Id = 2, Notes = "Test Gas Fill", Date = DateTime.Now }
+            };
+
+            _mockServiceRecordDataAccess.Setup(x => x.GetServiceRecordsByVehicleId(vehicleId))
+                .Returns(serviceRecords);
+            _mockGasRecordDataAccess.Setup(x => x.GetGasRecordsByVehicleId(vehicleId))
+                .Returns(gasRecords);
+
+            // Setup empty collections for other record types to prevent null reference exceptions
+            _mockCollisionRecordDataAccess.Setup(x => x.GetCollisionRecordsByVehicleId(vehicleId)).Returns(new List<CollisionRecord>());
+            _mockUpgradeRecordDataAccess.Setup(x => x.GetUpgradeRecordsByVehicleId(vehicleId)).Returns(new List<UpgradeRecord>());
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(new List<TaxRecord>());
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordsByVehicleId(vehicleId)).Returns(new List<SupplyRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(new List<OdometerRecord>());
+            _mockNoteDataAccess.Setup(x => x.GetNotesByVehicleId(vehicleId)).Returns(new List<Note>());
+            
+            // Setup user config to show both service and gas records
+            _testUserConfig.VisibleTabs = new List<ImportMode> { ImportMode.ServiceRecord, ImportMode.GasRecord };
+            _testUserConfig.UseDefaultCaseSensitiveSearch = false;
+            _mockConfigHelper.Setup(x => x.GetUserConfig(It.IsAny<ClaimsPrincipal>())).Returns(_testUserConfig);
+
+            // Act - case insensitive search
+            var result = _apiController.SearchRecords(vehicleId, searchQuery, caseSensitive: false);
+
+            // Assert
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            var model = Assert.IsAssignableFrom<List<SearchResult>>(jsonResult.Value);
+            
+            // Should find results from both record types
+            Assert.Equal(2, model.Count);
+            Assert.Contains(model, x => x.RecordType == ImportMode.ServiceRecord);
+            Assert.Contains(model, x => x.RecordType == ImportMode.GasRecord);
+        }
+    }
+}

--- a/Tests/Logic/LoginLogicTests.cs
+++ b/Tests/Logic/LoginLogicTests.cs
@@ -1,0 +1,404 @@
+using CarCareTracker.External.Interfaces;
+using CarCareTracker.Helper;
+using CarCareTracker.Logic;
+using CarCareTracker.Models;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Xunit;
+
+namespace CarCareTracker.Tests.Logic
+{
+    public class LoginLogicTests
+    {
+        private readonly Mock<IUserRecordDataAccess> _mockUserData;
+        private readonly Mock<ITokenRecordDataAccess> _mockTokenData;
+        private readonly Mock<IMailHelper> _mockMailHelper;
+        private readonly Mock<IConfigHelper> _mockConfigHelper;
+        private readonly Mock<IMemoryCache> _mockCache;
+        private readonly LoginLogic _loginLogic;
+
+        public LoginLogicTests()
+        {
+            _mockUserData = new Mock<IUserRecordDataAccess>();
+            _mockTokenData = new Mock<ITokenRecordDataAccess>();
+            _mockMailHelper = new Mock<IMailHelper>();
+            _mockConfigHelper = new Mock<IConfigHelper>();
+            _mockCache = new Mock<IMemoryCache>();
+            _loginLogic = new LoginLogic(
+                _mockUserData.Object,
+                _mockTokenData.Object,
+                _mockMailHelper.Object,
+                _mockConfigHelper.Object,
+                _mockCache.Object
+            );
+        }
+
+        [Fact]
+        public void CheckIfUserIsValid_RootUser_ReturnsTrue()
+        {
+            // Arrange
+            var userId = -1; // Root user
+
+            // Act
+            var result = _loginLogic.CheckIfUserIsValid(userId);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CheckIfUserIsValid_ExistingUser_ReturnsTrue()
+        {
+            // Arrange
+            var userId = 5;
+            var userData = new UserData { Id = 5, UserName = "testuser" };
+
+            _mockUserData.Setup(x => x.GetUserRecordById(userId)).Returns(userData);
+
+            // Act
+            var result = _loginLogic.CheckIfUserIsValid(userId);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CheckIfUserIsValid_NonExistentUser_ReturnsFalse()
+        {
+            // Arrange
+            var userId = 999;
+
+            _mockUserData.Setup(x => x.GetUserRecordById(userId)).Returns((UserData?)null);
+
+            // Act
+            var result = _loginLogic.CheckIfUserIsValid(userId);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void CheckIfUserIsValid_UserWithZeroId_ReturnsFalse()
+        {
+            // Arrange
+            var userId = 5;
+            var userData = new UserData { Id = 0, UserName = "testuser" }; // Invalid user
+
+            _mockUserData.Setup(x => x.GetUserRecordById(userId)).Returns(userData);
+
+            // Act
+            var result = _loginLogic.CheckIfUserIsValid(userId);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void MakeUserAdmin_ValidUser_UpdatesAdminStatus()
+        {
+            // Arrange
+            var userId = 5;
+            var isAdmin = true;
+            var userData = new UserData { Id = 5, UserName = "testuser", IsAdmin = false };
+
+            _mockUserData.Setup(x => x.GetUserRecordById(userId)).Returns(userData);
+            _mockUserData.Setup(x => x.SaveUserRecord(It.IsAny<UserData>())).Returns(true);
+
+            // Act
+            var result = _loginLogic.MakeUserAdmin(userId, isAdmin);
+
+            // Assert
+            Assert.True(result);
+            Assert.True(userData.IsAdmin);
+            _mockUserData.Verify(x => x.SaveUserRecord(userData), Times.Once);
+        }
+
+        [Fact]
+        public void MakeUserAdmin_InvalidUser_ReturnsFalse()
+        {
+            // Arrange
+            var userId = 999;
+            var isAdmin = true;
+
+            _mockUserData.Setup(x => x.GetUserRecordById(userId)).Returns((UserData?)null);
+
+            // Act
+            var result = _loginLogic.MakeUserAdmin(userId, isAdmin);
+
+            // Assert
+            Assert.False(result);
+            _mockUserData.Verify(x => x.SaveUserRecord(It.IsAny<UserData>()), Times.Never);
+        }
+
+        [Fact]
+        public void GenerateUserToken_NewEmail_CreatesTokenAndSendsEmail()
+        {
+            // Arrange
+            var emailAddress = "test@example.com";
+            var autoNotify = true;
+            var emptyToken = new Token { Id = 0 };
+
+            _mockTokenData.Setup(x => x.GetTokenRecordByEmailAddress(emailAddress)).Returns(emptyToken);
+            _mockTokenData.Setup(x => x.CreateNewToken(It.IsAny<Token>())).Returns(true);
+            _mockMailHelper.Setup(x => x.NotifyUserForRegistration(emailAddress, It.IsAny<string>())).Returns(OperationResponse.Succeed());
+
+            // Act
+            var result = _loginLogic.GenerateUserToken(emailAddress, autoNotify);
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.Equal("Token Generated!", result.Message);
+            _mockTokenData.Verify(x => x.CreateNewToken(It.Is<Token>(t => t.EmailAddress == emailAddress)), Times.Once);
+            _mockMailHelper.Verify(x => x.NotifyUserForRegistration(emailAddress, It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void GenerateUserToken_ExistingEmail_ReturnsFailed()
+        {
+            // Arrange
+            var emailAddress = "test@example.com";
+            var autoNotify = false;
+            var existingToken = new Token { Id = 1, EmailAddress = emailAddress };
+
+            _mockTokenData.Setup(x => x.GetTokenRecordByEmailAddress(emailAddress)).Returns(existingToken);
+
+            // Act
+            var result = _loginLogic.GenerateUserToken(emailAddress, autoNotify);
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Contains("existing token", result.Message);
+            _mockTokenData.Verify(x => x.CreateNewToken(It.IsAny<Token>()), Times.Never);
+        }
+
+        [Fact]
+        public void RegisterNewUser_ValidCredentials_CreatesUser()
+        {
+            // Arrange
+            var credentials = new LoginModel
+            {
+                EmailAddress = "test@example.com",
+                UserName = "testuser",
+                Password = "password123",
+                Token = "validtoken"
+            };
+            var validToken = new Token { Id = 1, EmailAddress = credentials.EmailAddress };
+            var emptyUser = new UserData { Id = 0 };
+
+            _mockTokenData.Setup(x => x.GetTokenRecordByBody(credentials.Token)).Returns(validToken);
+            _mockUserData.Setup(x => x.GetUserRecordByUserName(credentials.UserName)).Returns(emptyUser);
+            _mockUserData.Setup(x => x.GetUserRecordByEmailAddress(credentials.EmailAddress)).Returns(emptyUser);
+            _mockTokenData.Setup(x => x.DeleteToken(validToken.Id)).Returns(true);
+            _mockUserData.Setup(x => x.SaveUserRecord(It.IsAny<UserData>())).Returns(true);
+
+            // Act
+            var result = _loginLogic.RegisterNewUser(credentials);
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.Contains("redirected to the login page", result.Message);
+            _mockTokenData.Verify(x => x.DeleteToken(validToken.Id), Times.Once);
+            _mockUserData.Verify(x => x.SaveUserRecord(It.Is<UserData>(u => 
+                u.UserName == credentials.UserName && 
+                u.EmailAddress == credentials.EmailAddress)), Times.Once);
+        }
+
+        [Fact]
+        public void RegisterNewUser_InvalidToken_ReturnsFailed()
+        {
+            // Arrange
+            var credentials = new LoginModel
+            {
+                EmailAddress = "test@example.com",
+                UserName = "testuser",
+                Password = "password123",
+                Token = "invalidtoken"
+            };
+            var emptyToken = new Token { Id = 0 };
+
+            _mockTokenData.Setup(x => x.GetTokenRecordByBody(credentials.Token)).Returns(emptyToken);
+
+            // Act
+            var result = _loginLogic.RegisterNewUser(credentials);
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Equal("Invalid Token", result.Message);
+            _mockUserData.Verify(x => x.SaveUserRecord(It.IsAny<UserData>()), Times.Never);
+        }
+
+        [Fact]
+        public void RegisterNewUser_UsernameAlreadyTaken_ReturnsFailed()
+        {
+            // Arrange
+            var credentials = new LoginModel
+            {
+                EmailAddress = "test@example.com",
+                UserName = "existinguser",
+                Password = "password123",
+                Token = "validtoken"
+            };
+            var validToken = new Token { Id = 1, EmailAddress = credentials.EmailAddress };
+            var existingUser = new UserData { Id = 5, UserName = credentials.UserName };
+
+            _mockTokenData.Setup(x => x.GetTokenRecordByBody(credentials.Token)).Returns(validToken);
+            _mockUserData.Setup(x => x.GetUserRecordByUserName(credentials.UserName)).Returns(existingUser);
+
+            // Act
+            var result = _loginLogic.RegisterNewUser(credentials);
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Equal("Username already taken", result.Message);
+            _mockUserData.Verify(x => x.SaveUserRecord(It.IsAny<UserData>()), Times.Never);
+        }
+
+        [Fact]
+        public void RequestResetPassword_ExistingUser_GeneratesTokenAndReturnsSuccess()
+        {
+            // Arrange
+            var credentials = new LoginModel { UserName = "existinguser" };
+            var existingUser = new UserData { Id = 5, UserName = "existinguser", EmailAddress = "user@example.com" };
+            var emptyToken = new Token { Id = 0 };
+
+            _mockUserData.Setup(x => x.GetUserRecordByUserName(credentials.UserName)).Returns(existingUser);
+            _mockTokenData.Setup(x => x.GetTokenRecordByEmailAddress(existingUser.EmailAddress)).Returns(emptyToken);
+            _mockTokenData.Setup(x => x.CreateNewToken(It.IsAny<Token>())).Returns(true);
+            _mockMailHelper.Setup(x => x.NotifyUserForPasswordReset(existingUser.EmailAddress, It.IsAny<string>())).Returns(OperationResponse.Succeed());
+
+            // Act
+            var result = _loginLogic.RequestResetPassword(credentials);
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.Contains("should receive an email", result.Message);
+        }
+
+        [Fact]
+        public void RequestResetPassword_NonExistentUser_StillReturnsSuccessForSecurity()
+        {
+            // Arrange
+            var credentials = new LoginModel { UserName = "nonexistentuser" };
+            var emptyUser = new UserData { Id = 0 };
+
+            _mockUserData.Setup(x => x.GetUserRecordByUserName(credentials.UserName)).Returns(emptyUser);
+
+            // Act
+            var result = _loginLogic.RequestResetPassword(credentials);
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.Contains("should receive an email", result.Message);
+        }
+
+        [Fact]
+        public void ValidateUserCredentials_RootUser_ReturnsRootUserData()
+        {
+            // Arrange
+            var credentials = new LoginModel { UserName = "root", Password = "rootpassword" };
+
+            _mockConfigHelper.Setup(x => x.AuthenticateRootUser(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+
+            // Act
+            var result = _loginLogic.ValidateUserCredentials(credentials);
+
+            // Assert
+            Assert.Equal(-1, result.Id);
+            Assert.True(result.IsRootUser);
+            Assert.True(result.IsAdmin);
+            Assert.Equal(credentials.UserName, result.UserName);
+        }
+
+        [Fact]
+        public void ValidateUserCredentials_ValidDbUser_ReturnsUserData()
+        {
+            // Arrange
+            var credentials = new LoginModel { UserName = "testuser", Password = "password123" };
+            var userData = new UserData { Id = 5, UserName = "testuser", Password = "hashedpassword" };
+
+            _mockConfigHelper.Setup(x => x.AuthenticateRootUser(It.IsAny<string>(), It.IsAny<string>())).Returns(false);
+            _mockUserData.Setup(x => x.GetUserRecordByUserName(credentials.UserName)).Returns(userData);
+
+            // Note: This test assumes the GetHash method would return the same value for the same input
+            // In a real scenario, you'd need to mock or test the actual hash comparison
+
+            // Act
+            var result = _loginLogic.ValidateUserCredentials(credentials);
+
+            // Assert - This test would need adjustment based on actual hashing implementation
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void DeleteUser_CallsDeleteUserRecord()
+        {
+            // Arrange
+            var userId = 5;
+
+            _mockUserData.Setup(x => x.DeleteUserRecord(userId)).Returns(true);
+
+            // Act
+            var result = _loginLogic.DeleteUser(userId);
+
+            // Assert
+            Assert.True(result);
+            _mockUserData.Verify(x => x.DeleteUserRecord(userId), Times.Once);
+        }
+
+        [Fact]
+        public void DeleteUserToken_CallsDeleteToken()
+        {
+            // Arrange
+            var tokenId = 10;
+
+            _mockTokenData.Setup(x => x.DeleteToken(tokenId)).Returns(true);
+
+            // Act
+            var result = _loginLogic.DeleteUserToken(tokenId);
+
+            // Assert
+            Assert.True(result);
+            _mockTokenData.Verify(x => x.DeleteToken(tokenId), Times.Once);
+        }
+
+        [Fact]
+        public void GetAllUsers_ReturnsUserList()
+        {
+            // Arrange
+            var users = new List<UserData>
+            {
+                new UserData { Id = 1, UserName = "user1" },
+                new UserData { Id = 2, UserName = "user2" }
+            };
+
+            _mockUserData.Setup(x => x.GetUsers()).Returns(users);
+
+            // Act
+            var result = _loginLogic.GetAllUsers();
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Equal(users, result);
+        }
+
+        [Fact]
+        public void GetAllTokens_ReturnsTokenList()
+        {
+            // Arrange
+            var tokens = new List<Token>
+            {
+                new Token { Id = 1, EmailAddress = "email1@example.com" },
+                new Token { Id = 2, EmailAddress = "email2@example.com" }
+            };
+
+            _mockTokenData.Setup(x => x.GetTokens()).Returns(tokens);
+
+            // Act
+            var result = _loginLogic.GetAllTokens();
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Equal(tokens, result);
+        }
+    }
+}

--- a/Tests/Logic/OdometerLogicTests.cs
+++ b/Tests/Logic/OdometerLogicTests.cs
@@ -1,0 +1,240 @@
+using CarCareTracker.External.Interfaces;
+using CarCareTracker.Logic;
+using CarCareTracker.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace CarCareTracker.Tests.Logic
+{
+    public class OdometerLogicTests
+    {
+        private readonly Mock<IOdometerRecordDataAccess> _mockOdometerRecordDataAccess;
+        private readonly Mock<ILogger<IOdometerLogic>> _mockLogger;
+        private readonly OdometerLogic _odometerLogic;
+
+        public OdometerLogicTests()
+        {
+            _mockOdometerRecordDataAccess = new Mock<IOdometerRecordDataAccess>();
+            _mockLogger = new Mock<ILogger<IOdometerLogic>>();
+            _odometerLogic = new OdometerLogic(_mockOdometerRecordDataAccess.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public void GetLastOdometerRecordMileage_WithProvidedRecords_ReturnsMaxMileage()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var odometerRecords = new List<OdometerRecord>
+            {
+                new OdometerRecord { Mileage = 1000 },
+                new OdometerRecord { Mileage = 1500 },
+                new OdometerRecord { Mileage = 1200 }
+            };
+
+            // Act
+            var result = _odometerLogic.GetLastOdometerRecordMileage(vehicleId, odometerRecords);
+
+            // Assert
+            Assert.Equal(1500, result);
+        }
+
+        [Fact]
+        public void GetLastOdometerRecordMileage_WithEmptyProvidedRecords_FetchesFromDatabase()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var emptyRecords = new List<OdometerRecord>();
+            var dbRecords = new List<OdometerRecord>
+            {
+                new OdometerRecord { Mileage = 2000 },
+                new OdometerRecord { Mileage = 2500 }
+            };
+
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(dbRecords);
+
+            // Act
+            var result = _odometerLogic.GetLastOdometerRecordMileage(vehicleId, emptyRecords);
+
+            // Assert
+            Assert.Equal(2500, result);
+            _mockOdometerRecordDataAccess.Verify(x => x.GetOdometerRecordsByVehicleId(vehicleId), Times.Once);
+        }
+
+        [Fact]
+        public void GetLastOdometerRecordMileage_WithNoRecords_ReturnsZero()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var emptyRecords = new List<OdometerRecord>();
+
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(new List<OdometerRecord>());
+
+            // Act
+            var result = _odometerLogic.GetLastOdometerRecordMileage(vehicleId, emptyRecords);
+
+            // Assert
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void AutoInsertOdometerRecord_WithDefaultMileage_ReturnsFalse()
+        {
+            // Arrange
+            var odometer = new OdometerRecord { Mileage = 0, VehicleId = 1 };
+
+            // Act
+            var result = _odometerLogic.AutoInsertOdometerRecord(odometer);
+
+            // Assert
+            Assert.False(result);
+            _mockOdometerRecordDataAccess.Verify(x => x.SaveOdometerRecordToVehicle(It.IsAny<OdometerRecord>()), Times.Never);
+        }
+
+        [Fact]
+        public void AutoInsertOdometerRecord_WithValidMileage_SetsInitialMileageAndSaves()
+        {
+            // Arrange
+            var odometer = new OdometerRecord { Mileage = 1500, VehicleId = 1 };
+            var existingRecords = new List<OdometerRecord>
+            {
+                new OdometerRecord { Mileage = 1200 }
+            };
+
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(1)).Returns(existingRecords);
+            _mockOdometerRecordDataAccess.Setup(x => x.SaveOdometerRecordToVehicle(It.IsAny<OdometerRecord>())).Returns(true);
+
+            // Act
+            var result = _odometerLogic.AutoInsertOdometerRecord(odometer);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(1200, odometer.InitialMileage);
+            _mockOdometerRecordDataAccess.Verify(x => x.SaveOdometerRecordToVehicle(odometer), Times.Once);
+        }
+
+        [Fact]
+        public void AutoInsertOdometerRecord_WithNoExistingRecords_SetsInitialMileageToCurrentMileage()
+        {
+            // Arrange
+            var odometer = new OdometerRecord { Mileage = 1500, VehicleId = 1 };
+
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(1)).Returns(new List<OdometerRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.SaveOdometerRecordToVehicle(It.IsAny<OdometerRecord>())).Returns(true);
+
+            // Act
+            var result = _odometerLogic.AutoInsertOdometerRecord(odometer);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(1500, odometer.InitialMileage);
+            _mockOdometerRecordDataAccess.Verify(x => x.SaveOdometerRecordToVehicle(odometer), Times.Once);
+        }
+
+        [Fact]
+        public void AutoInsertOdometerRecord_SaveFails_ReturnsFalse()
+        {
+            // Arrange
+            var odometer = new OdometerRecord { Mileage = 1500, VehicleId = 1 };
+
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(1)).Returns(new List<OdometerRecord>());
+            _mockOdometerRecordDataAccess.Setup(x => x.SaveOdometerRecordToVehicle(It.IsAny<OdometerRecord>())).Returns(false);
+
+            // Act
+            var result = _odometerLogic.AutoInsertOdometerRecord(odometer);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void AutoConvertOdometerRecord_OrdersRecordsAndSetsInitialMileage()
+        {
+            // Arrange
+            var odometerRecords = new List<OdometerRecord>
+            {
+                new OdometerRecord { Id = 3, Date = DateTime.Parse("2023-03-01"), Mileage = 1500 },
+                new OdometerRecord { Id = 1, Date = DateTime.Parse("2023-01-01"), Mileage = 1000 },
+                new OdometerRecord { Id = 2, Date = DateTime.Parse("2023-02-01"), Mileage = 1200 }
+            };
+
+            _mockOdometerRecordDataAccess.Setup(x => x.SaveOdometerRecordToVehicle(It.IsAny<OdometerRecord>())).Returns(true);
+
+            // Act
+            var result = _odometerLogic.AutoConvertOdometerRecord(odometerRecords);
+
+            // Assert
+            Assert.Equal(3, result.Count);
+            
+            // Verify ordering by date and then by mileage
+            Assert.Equal(1, result[0].Id); // January record
+            Assert.Equal(2, result[1].Id); // February record
+            Assert.Equal(3, result[2].Id); // March record
+
+            // Verify initial mileage settings
+            Assert.Equal(1000, result[0].InitialMileage); // First record uses its own mileage
+            Assert.Equal(1000, result[1].InitialMileage); // Second record uses previous mileage
+            Assert.Equal(1200, result[2].InitialMileage); // Third record uses previous mileage
+
+            // Verify all records were saved
+            _mockOdometerRecordDataAccess.Verify(x => x.SaveOdometerRecordToVehicle(It.IsAny<OdometerRecord>()), Times.Exactly(3));
+        }
+
+        [Fact]
+        public void AutoConvertOdometerRecord_SingleRecord_SetsInitialMileageToOwnMileage()
+        {
+            // Arrange
+            var odometerRecords = new List<OdometerRecord>
+            {
+                new OdometerRecord { Id = 1, Date = DateTime.Parse("2023-01-01"), Mileage = 1000 }
+            };
+
+            _mockOdometerRecordDataAccess.Setup(x => x.SaveOdometerRecordToVehicle(It.IsAny<OdometerRecord>())).Returns(true);
+
+            // Act
+            var result = _odometerLogic.AutoConvertOdometerRecord(odometerRecords);
+
+            // Assert
+            Assert.Single(result);
+            Assert.Equal(1000, result[0].InitialMileage);
+            _mockOdometerRecordDataAccess.Verify(x => x.SaveOdometerRecordToVehicle(It.IsAny<OdometerRecord>()), Times.Once);
+        }
+
+        [Fact]
+        public void AutoConvertOdometerRecord_EmptyList_ReturnsEmptyList()
+        {
+            // Arrange
+            var odometerRecords = new List<OdometerRecord>();
+
+            // Act
+            var result = _odometerLogic.AutoConvertOdometerRecord(odometerRecords);
+
+            // Assert
+            Assert.Empty(result);
+            _mockOdometerRecordDataAccess.Verify(x => x.SaveOdometerRecordToVehicle(It.IsAny<OdometerRecord>()), Times.Never);
+        }
+
+        [Fact]
+        public void AutoConvertOdometerRecord_SameDateDifferentMileage_OrdersByMileage()
+        {
+            // Arrange
+            var samDate = DateTime.Parse("2023-01-01");
+            var odometerRecords = new List<OdometerRecord>
+            {
+                new OdometerRecord { Id = 2, Date = samDate, Mileage = 1200 },
+                new OdometerRecord { Id = 1, Date = samDate, Mileage = 1000 }
+            };
+
+            _mockOdometerRecordDataAccess.Setup(x => x.SaveOdometerRecordToVehicle(It.IsAny<OdometerRecord>())).Returns(true);
+
+            // Act
+            var result = _odometerLogic.AutoConvertOdometerRecord(odometerRecords);
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1, result[0].Id); // Lower mileage comes first
+            Assert.Equal(2, result[1].Id); // Higher mileage comes second
+            Assert.Equal(1000, result[1].InitialMileage); // Second record uses first record's mileage
+        }
+    }
+}

--- a/Tests/Logic/UserLogicTests.cs
+++ b/Tests/Logic/UserLogicTests.cs
@@ -1,0 +1,303 @@
+using CarCareTracker.External.Interfaces;
+using CarCareTracker.Logic;
+using CarCareTracker.Models;
+using Moq;
+using Xunit;
+
+namespace CarCareTracker.Tests.Logic
+{
+    public class UserLogicTests
+    {
+        private readonly Mock<IUserAccessDataAccess> _mockUserAccess;
+        private readonly Mock<IUserRecordDataAccess> _mockUserData;
+        private readonly UserLogic _userLogic;
+
+        public UserLogicTests()
+        {
+            _mockUserAccess = new Mock<IUserAccessDataAccess>();
+            _mockUserData = new Mock<IUserRecordDataAccess>();
+            _userLogic = new UserLogic(_mockUserAccess.Object, _mockUserData.Object);
+        }
+
+        [Fact]
+        public void GetCollaboratorsForVehicle_ReturnsCorrectCollaborators()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var userAccess = new List<UserAccess>
+            {
+                new UserAccess { Id = new UserVehicle { UserId = 1, VehicleId = vehicleId } },
+                new UserAccess { Id = new UserVehicle { UserId = 2, VehicleId = vehicleId } }
+            };
+            var userData1 = new UserData { Id = 1, UserName = "user1" };
+            var userData2 = new UserData { Id = 2, UserName = "user2" };
+
+            _mockUserAccess.Setup(x => x.GetUserAccessByVehicleId(vehicleId)).Returns(userAccess);
+            _mockUserData.Setup(x => x.GetUserRecordById(1)).Returns(userData1);
+            _mockUserData.Setup(x => x.GetUserRecordById(2)).Returns(userData2);
+
+            // Act
+            var result = _userLogic.GetCollaboratorsForVehicle(vehicleId);
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Equal("user1", result[0].UserName);
+            Assert.Equal("user2", result[1].UserName);
+        }
+
+        [Fact]
+        public void AddCollaboratorToVehicle_UserExists_ReturnsSuccess()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var username = "testuser";
+            var existingUser = new UserData { Id = 5, UserName = username };
+
+            _mockUserData.Setup(x => x.GetUserRecordByUserName(username)).Returns(existingUser);
+            _mockUserAccess.Setup(x => x.GetUserAccessByVehicleAndUserId(existingUser.Id, vehicleId)).Returns((UserAccess?)null);
+            _mockUserAccess.Setup(x => x.SaveUserAccess(It.IsAny<UserAccess>())).Returns(true);
+
+            // Act
+            var result = _userLogic.AddCollaboratorToVehicle(vehicleId, username);
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.Equal("Collaborator Added", result.Message);
+        }
+
+        [Fact]
+        public void AddCollaboratorToVehicle_UserDoesNotExist_ReturnsFailed()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var username = "nonexistentuser";
+            var emptyUser = new UserData { Id = 0 };
+
+            _mockUserData.Setup(x => x.GetUserRecordByUserName(username)).Returns(emptyUser);
+
+            // Act
+            var result = _userLogic.AddCollaboratorToVehicle(vehicleId, username);
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Equal($"Unable to find user {username} in the system", result.Message);
+        }
+
+        [Fact]
+        public void AddCollaboratorToVehicle_UserAlreadyCollaborator_ReturnsFailed()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var username = "testuser";
+            var existingUser = new UserData { Id = 5, UserName = username };
+            var existingAccess = new UserAccess { Id = new UserVehicle { UserId = 5, VehicleId = vehicleId } };
+
+            _mockUserData.Setup(x => x.GetUserRecordByUserName(username)).Returns(existingUser);
+            _mockUserAccess.Setup(x => x.GetUserAccessByVehicleAndUserId(existingUser.Id, vehicleId)).Returns(existingAccess);
+
+            // Act
+            var result = _userLogic.AddCollaboratorToVehicle(vehicleId, username);
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Equal("User is already a collaborator", result.Message);
+        }
+
+        [Fact]
+        public void AddUserAccessToVehicle_RootUser_ReturnsTrue()
+        {
+            // Arrange
+            var userId = -1; // Root user
+            var vehicleId = 1;
+
+            // Act
+            var result = _userLogic.AddUserAccessToVehicle(userId, vehicleId);
+
+            // Assert
+            Assert.True(result);
+            _mockUserAccess.Verify(x => x.SaveUserAccess(It.IsAny<UserAccess>()), Times.Never);
+        }
+
+        [Fact]
+        public void AddUserAccessToVehicle_RegularUser_CallsSaveUserAccess()
+        {
+            // Arrange
+            var userId = 5;
+            var vehicleId = 1;
+
+            _mockUserAccess.Setup(x => x.SaveUserAccess(It.IsAny<UserAccess>())).Returns(true);
+
+            // Act
+            var result = _userLogic.AddUserAccessToVehicle(userId, vehicleId);
+
+            // Assert
+            Assert.True(result);
+            _mockUserAccess.Verify(x => x.SaveUserAccess(It.Is<UserAccess>(ua => 
+                ua.Id.UserId == userId && ua.Id.VehicleId == vehicleId)), Times.Once);
+        }
+
+        [Fact]
+        public void FilterUserVehicles_RootUser_ReturnsAllVehicles()
+        {
+            // Arrange
+            var userId = -1; // Root user
+            var vehicles = new List<Vehicle>
+            {
+                new Vehicle { Id = 1, Make = "Toyota" },
+                new Vehicle { Id = 2, Make = "Honda" }
+            };
+
+            // Act
+            var result = _userLogic.FilterUserVehicles(vehicles, userId);
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Equal(vehicles, result);
+        }
+
+        [Fact]
+        public void FilterUserVehicles_RegularUserWithAccess_ReturnsAccessibleVehicles()
+        {
+            // Arrange
+            var userId = 5;
+            var vehicles = new List<Vehicle>
+            {
+                new Vehicle { Id = 1, Make = "Toyota" },
+                new Vehicle { Id = 2, Make = "Honda" },
+                new Vehicle { Id = 3, Make = "Ford" }
+            };
+            var userAccess = new List<UserAccess>
+            {
+                new UserAccess { Id = new UserVehicle { UserId = userId, VehicleId = 1 } },
+                new UserAccess { Id = new UserVehicle { UserId = userId, VehicleId = 3 } }
+            };
+
+            _mockUserAccess.Setup(x => x.GetUserAccessByUserId(userId)).Returns(userAccess);
+
+            // Act
+            var result = _userLogic.FilterUserVehicles(vehicles, userId);
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, v => v.Id == 1);
+            Assert.Contains(result, v => v.Id == 3);
+            Assert.DoesNotContain(result, v => v.Id == 2);
+        }
+
+        [Fact]
+        public void FilterUserVehicles_RegularUserWithoutAccess_ReturnsEmptyList()
+        {
+            // Arrange
+            var userId = 5;
+            var vehicles = new List<Vehicle>
+            {
+                new Vehicle { Id = 1, Make = "Toyota" },
+                new Vehicle { Id = 2, Make = "Honda" }
+            };
+
+            _mockUserAccess.Setup(x => x.GetUserAccessByUserId(userId)).Returns(new List<UserAccess>());
+
+            // Act
+            var result = _userLogic.FilterUserVehicles(vehicles, userId);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void UserCanEditVehicle_RootUser_ReturnsTrue()
+        {
+            // Arrange
+            var userId = -1; // Root user
+            var vehicleId = 1;
+
+            // Act
+            var result = _userLogic.UserCanEditVehicle(userId, vehicleId);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void UserCanEditVehicle_UserWithAccess_ReturnsTrue()
+        {
+            // Arrange
+            var userId = 5;
+            var vehicleId = 1;
+            var userAccess = new UserAccess { Id = new UserVehicle { UserId = userId, VehicleId = vehicleId } };
+
+            _mockUserAccess.Setup(x => x.GetUserAccessByVehicleAndUserId(userId, vehicleId)).Returns(userAccess);
+
+            // Act
+            var result = _userLogic.UserCanEditVehicle(userId, vehicleId);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void UserCanEditVehicle_UserWithoutAccess_ReturnsFalse()
+        {
+            // Arrange
+            var userId = 5;
+            var vehicleId = 1;
+
+            _mockUserAccess.Setup(x => x.GetUserAccessByVehicleAndUserId(userId, vehicleId)).Returns((UserAccess?)null);
+
+            // Act
+            var result = _userLogic.UserCanEditVehicle(userId, vehicleId);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void DeleteCollaboratorFromVehicle_CallsDeleteUserAccess()
+        {
+            // Arrange
+            var userId = 5;
+            var vehicleId = 1;
+
+            _mockUserAccess.Setup(x => x.DeleteUserAccess(userId, vehicleId)).Returns(true);
+
+            // Act
+            var result = _userLogic.DeleteCollaboratorFromVehicle(userId, vehicleId);
+
+            // Assert
+            Assert.True(result);
+            _mockUserAccess.Verify(x => x.DeleteUserAccess(userId, vehicleId), Times.Once);
+        }
+
+        [Fact]
+        public void DeleteAllAccessToVehicle_CallsDeleteAllAccessRecordsByVehicleId()
+        {
+            // Arrange
+            var vehicleId = 1;
+
+            _mockUserAccess.Setup(x => x.DeleteAllAccessRecordsByVehicleId(vehicleId)).Returns(true);
+
+            // Act
+            var result = _userLogic.DeleteAllAccessToVehicle(vehicleId);
+
+            // Assert
+            Assert.True(result);
+            _mockUserAccess.Verify(x => x.DeleteAllAccessRecordsByVehicleId(vehicleId), Times.Once);
+        }
+
+        [Fact]
+        public void DeleteAllAccessToUser_CallsDeleteAllAccessRecordsByUserId()
+        {
+            // Arrange
+            var userId = 5;
+
+            _mockUserAccess.Setup(x => x.DeleteAllAccessRecordsByUserId(userId)).Returns(true);
+
+            // Act
+            var result = _userLogic.DeleteAllAccessToUser(userId);
+
+            // Assert
+            Assert.True(result);
+            _mockUserAccess.Verify(x => x.DeleteAllAccessRecordsByUserId(userId), Times.Once);
+        }
+    }
+}

--- a/Tests/Logic/VehicleLogicTests.cs
+++ b/Tests/Logic/VehicleLogicTests.cs
@@ -1,0 +1,359 @@
+using CarCareTracker.External.Interfaces;
+using CarCareTracker.Helper;
+using CarCareTracker.Logic;
+using CarCareTracker.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace CarCareTracker.Tests.Logic
+{
+    public class VehicleLogicTests
+    {
+        private readonly Mock<IServiceRecordDataAccess> _mockServiceRecordDataAccess;
+        private readonly Mock<IGasRecordDataAccess> _mockGasRecordDataAccess;
+        private readonly Mock<ICollisionRecordDataAccess> _mockCollisionRecordDataAccess;
+        private readonly Mock<IUpgradeRecordDataAccess> _mockUpgradeRecordDataAccess;
+        private readonly Mock<ITaxRecordDataAccess> _mockTaxRecordDataAccess;
+        private readonly Mock<IOdometerRecordDataAccess> _mockOdometerRecordDataAccess;
+        private readonly Mock<IReminderRecordDataAccess> _mockReminderRecordDataAccess;
+        private readonly Mock<IPlanRecordDataAccess> _mockPlanRecordDataAccess;
+        private readonly Mock<IReminderHelper> _mockReminderHelper;
+        private readonly Mock<IVehicleDataAccess> _mockVehicleDataAccess;
+        private readonly Mock<ISupplyRecordDataAccess> _mockSupplyRecordDataAccess;
+        private readonly Mock<ILogger<VehicleLogic>> _mockLogger;
+        private readonly VehicleLogic _vehicleLogic;
+
+        public VehicleLogicTests()
+        {
+            _mockServiceRecordDataAccess = new Mock<IServiceRecordDataAccess>();
+            _mockGasRecordDataAccess = new Mock<IGasRecordDataAccess>();
+            _mockCollisionRecordDataAccess = new Mock<ICollisionRecordDataAccess>();
+            _mockUpgradeRecordDataAccess = new Mock<IUpgradeRecordDataAccess>();
+            _mockTaxRecordDataAccess = new Mock<ITaxRecordDataAccess>();
+            _mockOdometerRecordDataAccess = new Mock<IOdometerRecordDataAccess>();
+            _mockReminderRecordDataAccess = new Mock<IReminderRecordDataAccess>();
+            _mockPlanRecordDataAccess = new Mock<IPlanRecordDataAccess>();
+            _mockReminderHelper = new Mock<IReminderHelper>();
+            _mockVehicleDataAccess = new Mock<IVehicleDataAccess>();
+            _mockSupplyRecordDataAccess = new Mock<ISupplyRecordDataAccess>();
+            _mockLogger = new Mock<ILogger<VehicleLogic>>();
+
+            _vehicleLogic = new VehicleLogic(
+                _mockServiceRecordDataAccess.Object,
+                _mockGasRecordDataAccess.Object,
+                _mockCollisionRecordDataAccess.Object,
+                _mockUpgradeRecordDataAccess.Object,
+                _mockTaxRecordDataAccess.Object,
+                _mockOdometerRecordDataAccess.Object,
+                _mockReminderRecordDataAccess.Object,
+                _mockPlanRecordDataAccess.Object,
+                _mockReminderHelper.Object,
+                _mockVehicleDataAccess.Object,
+                _mockSupplyRecordDataAccess.Object,
+                _mockLogger.Object
+            );
+        }
+
+        [Fact]
+        public void GetVehicleRecords_ReturnsCorrectRecords()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var serviceRecords = new List<ServiceRecord> { new ServiceRecord { Id = 1, Cost = 100 } };
+            var gasRecords = new List<GasRecord> { new GasRecord { Id = 1, Cost = 50 } };
+            var collisionRecords = new List<CollisionRecord> { new CollisionRecord { Id = 1, Cost = 200 } };
+            var taxRecords = new List<TaxRecord> { new TaxRecord { Id = 1, Cost = 75 } };
+            var upgradeRecords = new List<UpgradeRecord> { new UpgradeRecord { Id = 1, Cost = 300 } };
+            var odometerRecords = new List<OdometerRecord> { new OdometerRecord { Id = 1, Mileage = 1000 } };
+
+            _mockServiceRecordDataAccess.Setup(x => x.GetServiceRecordsByVehicleId(vehicleId)).Returns(serviceRecords);
+            _mockGasRecordDataAccess.Setup(x => x.GetGasRecordsByVehicleId(vehicleId)).Returns(gasRecords);
+            _mockCollisionRecordDataAccess.Setup(x => x.GetCollisionRecordsByVehicleId(vehicleId)).Returns(collisionRecords);
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(taxRecords);
+            _mockUpgradeRecordDataAccess.Setup(x => x.GetUpgradeRecordsByVehicleId(vehicleId)).Returns(upgradeRecords);
+            _mockOdometerRecordDataAccess.Setup(x => x.GetOdometerRecordsByVehicleId(vehicleId)).Returns(odometerRecords);
+
+            // Act
+            var result = _vehicleLogic.GetVehicleRecords(vehicleId);
+
+            // Assert
+            Assert.Equal(serviceRecords, result.ServiceRecords);
+            Assert.Equal(gasRecords, result.GasRecords);
+            Assert.Equal(collisionRecords, result.CollisionRecords);
+            Assert.Equal(taxRecords, result.TaxRecords);
+            Assert.Equal(upgradeRecords, result.UpgradeRecords);
+            Assert.Equal(odometerRecords, result.OdometerRecords);
+        }
+
+        [Fact]
+        public void GetVehicleTotalCost_CalculatesCorrectTotal()
+        {
+            // Arrange
+            var vehicleRecords = new VehicleRecords
+            {
+                ServiceRecords = new List<ServiceRecord> { new ServiceRecord { Cost = 100 }, new ServiceRecord { Cost = 150 } },
+                GasRecords = new List<GasRecord> { new GasRecord { Cost = 50 }, new GasRecord { Cost = 75 } },
+                CollisionRecords = new List<CollisionRecord> { new CollisionRecord { Cost = 200 } },
+                TaxRecords = new List<TaxRecord> { new TaxRecord { Cost = 80 } },
+                UpgradeRecords = new List<UpgradeRecord> { new UpgradeRecord { Cost = 300 } }
+            };
+
+            // Act
+            var result = _vehicleLogic.GetVehicleTotalCost(vehicleRecords);
+
+            // Assert
+            Assert.Equal(955, result); // 250 + 125 + 200 + 80 + 300
+        }
+
+        [Fact]
+        public void GetMaxMileage_WithVehicleRecords_ReturnsCorrectMaxMileage()
+        {
+            // Arrange
+            var vehicleRecords = new VehicleRecords
+            {
+                ServiceRecords = new List<ServiceRecord> { new ServiceRecord { Mileage = 1000 }, new ServiceRecord { Mileage = 1500 } },
+                GasRecords = new List<GasRecord> { new GasRecord { Mileage = 1200 } },
+                CollisionRecords = new List<CollisionRecord> { new CollisionRecord { Mileage = 800 } },
+                UpgradeRecords = new List<UpgradeRecord> { new UpgradeRecord { Mileage = 2000 } },
+                OdometerRecords = new List<OdometerRecord> { new OdometerRecord { Mileage = 1800 } }
+            };
+
+            // Act
+            var result = _vehicleLogic.GetMaxMileage(vehicleRecords);
+
+            // Assert
+            Assert.Equal(2000, result);
+        }
+
+        [Fact]
+        public void GetMaxMileage_WithVehicleRecords_EmptyRecords_ReturnsZero()
+        {
+            // Arrange
+            var vehicleRecords = new VehicleRecords
+            {
+                ServiceRecords = new List<ServiceRecord>(),
+                GasRecords = new List<GasRecord>(),
+                CollisionRecords = new List<CollisionRecord>(),
+                UpgradeRecords = new List<UpgradeRecord>(),
+                OdometerRecords = new List<OdometerRecord>()
+            };
+
+            // Act
+            var result = _vehicleLogic.GetMaxMileage(vehicleRecords);
+
+            // Assert
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void GetMinMileage_WithVehicleRecords_ReturnsCorrectMinMileage()
+        {
+            // Arrange
+            var vehicleRecords = new VehicleRecords
+            {
+                ServiceRecords = new List<ServiceRecord> { new ServiceRecord { Mileage = 1000 }, new ServiceRecord { Mileage = 1500 } },
+                GasRecords = new List<GasRecord> { new GasRecord { Mileage = 1200 } },
+                CollisionRecords = new List<CollisionRecord> { new CollisionRecord { Mileage = 800 } },
+                UpgradeRecords = new List<UpgradeRecord> { new UpgradeRecord { Mileage = 2000 } },
+                OdometerRecords = new List<OdometerRecord> { new OdometerRecord { Mileage = 1800 } }
+            };
+
+            // Act
+            var result = _vehicleLogic.GetMinMileage(vehicleRecords);
+
+            // Assert
+            Assert.Equal(800, result);
+        }
+
+        [Fact]
+        public void GetMinMileage_WithVehicleRecords_IgnoresDefaultMileage()
+        {
+            // Arrange
+            var vehicleRecords = new VehicleRecords
+            {
+                ServiceRecords = new List<ServiceRecord> { new ServiceRecord { Mileage = 0 }, new ServiceRecord { Mileage = 1500 } },
+                GasRecords = new List<GasRecord> { new GasRecord { Mileage = 1200 } },
+                CollisionRecords = new List<CollisionRecord> { new CollisionRecord { Mileage = 800 } },
+                UpgradeRecords = new List<UpgradeRecord> { new UpgradeRecord { Mileage = 0 } },
+                OdometerRecords = new List<OdometerRecord> { new OdometerRecord { Mileage = 1800 } }
+            };
+
+            // Act
+            var result = _vehicleLogic.GetMinMileage(vehicleRecords);
+
+            // Assert
+            Assert.Equal(800, result);
+        }
+
+        [Fact]
+        public void GetOwnershipDays_WithYearSpecified_CalculatesCorrectDays()
+        {
+            // Arrange
+            var purchaseDate = "2023-01-01";
+            var soldDate = "";
+            var year = 2023;
+            var serviceRecords = new List<ServiceRecord>();
+            var collisionRecords = new List<CollisionRecord>();
+            var gasRecords = new List<GasRecord>();
+            var upgradeRecords = new List<UpgradeRecord>();
+            var odometerRecords = new List<OdometerRecord>();
+            var taxRecords = new List<TaxRecord>();
+
+            // Act
+            var result = _vehicleLogic.GetOwnershipDays(purchaseDate, soldDate, year, serviceRecords, collisionRecords, gasRecords, upgradeRecords, odometerRecords, taxRecords);
+
+            // Assert
+            Assert.True(result >= 0);
+            Assert.True(result <= 365);
+        }
+
+        [Fact]
+        public void GetVehicleHasUrgentOrPastDueReminders_WithUrgentReminders_ReturnsTrue()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var currentMileage = 1000;
+            var reminders = new List<ReminderRecord> { new ReminderRecord { Id = 1 } };
+            var reminderViewModels = new List<ReminderRecordViewModel>
+            {
+                new ReminderRecordViewModel { Urgency = ReminderUrgency.VeryUrgent }
+            };
+
+            _mockReminderRecordDataAccess.Setup(x => x.GetReminderRecordsByVehicleId(vehicleId)).Returns(reminders);
+            _mockReminderHelper.Setup(x => x.GetReminderRecordViewModels(reminders, currentMileage, It.IsAny<DateTime>())).Returns(reminderViewModels);
+
+            // Act
+            var result = _vehicleLogic.GetVehicleHasUrgentOrPastDueReminders(vehicleId, currentMileage);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void GetVehicleHasUrgentOrPastDueReminders_WithoutUrgentReminders_ReturnsFalse()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var currentMileage = 1000;
+            var reminders = new List<ReminderRecord> { new ReminderRecord { Id = 1 } };
+            var reminderViewModels = new List<ReminderRecordViewModel>
+            {
+                new ReminderRecordViewModel { Urgency = ReminderUrgency.NotUrgent }
+            };
+
+            _mockReminderRecordDataAccess.Setup(x => x.GetReminderRecordsByVehicleId(vehicleId)).Returns(reminders);
+            _mockReminderHelper.Setup(x => x.GetReminderRecordViewModels(reminders, currentMileage, It.IsAny<DateTime>())).Returns(reminderViewModels);
+
+            // Act
+            var result = _vehicleLogic.GetVehicleHasUrgentOrPastDueReminders(vehicleId, currentMileage);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void UpdateRecurringTaxes_VehicleSold_ReturnsFalse()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var vehicle = new Vehicle { Id = vehicleId, SoldDate = "2023-12-31" };
+
+            _mockVehicleDataAccess.Setup(x => x.GetVehicleById(vehicleId)).Returns(vehicle);
+
+            // Act
+            var result = _vehicleLogic.UpdateRecurringTaxes(vehicleId);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void UpdateRecurringTaxes_NoOutdatedRecurringTaxes_ReturnsFalse()
+        {
+            // Arrange
+            var vehicleId = 1;
+            var vehicle = new Vehicle { Id = vehicleId, SoldDate = "" };
+            var taxRecords = new List<TaxRecord>
+            {
+                new TaxRecord { IsRecurring = false, Date = DateTime.Now.AddDays(-30) },
+                new TaxRecord { IsRecurring = true, Date = DateTime.Now.AddDays(-1), RecurringInterval = ReminderMonthInterval.OneMonth }
+            };
+
+            _mockVehicleDataAccess.Setup(x => x.GetVehicleById(vehicleId)).Returns(vehicle);
+            _mockTaxRecordDataAccess.Setup(x => x.GetTaxRecordsByVehicleId(vehicleId)).Returns(taxRecords);
+
+            // Act
+            var result = _vehicleLogic.UpdateRecurringTaxes(vehicleId);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void RestoreSupplyRecordsByUsage_ValidSupply_UpdatesSupplyRecord()
+        {
+            // Arrange
+            var supplyUsage = new List<SupplyUsageHistory>
+            {
+                new SupplyUsageHistory { Id = 1, Quantity = 5, Cost = 25 }
+            };
+            var usageDescription = "Test restoration";
+            var existingSupply = new SupplyRecord
+            {
+                Id = 1,
+                Quantity = 10,
+                Cost = 50,
+                RequisitionHistory = new List<SupplyUsageHistory>()
+            };
+
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordById(1)).Returns(existingSupply);
+            _mockSupplyRecordDataAccess.Setup(x => x.SaveSupplyRecordToVehicle(It.IsAny<SupplyRecord>())).Returns(true);
+
+            // Act
+            _vehicleLogic.RestoreSupplyRecordsByUsage(supplyUsage, usageDescription);
+
+            // Assert
+            _mockSupplyRecordDataAccess.Verify(x => x.SaveSupplyRecordToVehicle(It.Is<SupplyRecord>(s =>
+                s.Quantity == 15 && s.Cost == 75 && s.RequisitionHistory.Count == 1)), Times.Once);
+        }
+
+        [Fact]
+        public void RestoreSupplyRecordsByUsage_InvalidSupplyId_SkipsRecord()
+        {
+            // Arrange
+            var supplyUsage = new List<SupplyUsageHistory>
+            {
+                new SupplyUsageHistory { Id = 0, Quantity = 5, Cost = 25 } // Default ID
+            };
+            var usageDescription = "Test restoration";
+
+            // Act
+            _vehicleLogic.RestoreSupplyRecordsByUsage(supplyUsage, usageDescription);
+
+            // Assert
+            _mockSupplyRecordDataAccess.Verify(x => x.GetSupplyRecordById(It.IsAny<int>()), Times.Never);
+            _mockSupplyRecordDataAccess.Verify(x => x.SaveSupplyRecordToVehicle(It.IsAny<SupplyRecord>()), Times.Never);
+        }
+
+        [Fact]
+        public void RestoreSupplyRecordsByUsage_SupplyNotFound_DoesNotSaveRecord()
+        {
+            // Arrange
+            var supplyUsage = new List<SupplyUsageHistory>
+            {
+                new SupplyUsageHistory { Id = 999, Quantity = 5, Cost = 25 }
+            };
+            var usageDescription = "Test restoration";
+
+            _mockSupplyRecordDataAccess.Setup(x => x.GetSupplyRecordById(999)).Returns((SupplyRecord)null);
+
+            // Act
+            _vehicleLogic.RestoreSupplyRecordsByUsage(supplyUsage, usageDescription);
+
+            // Assert
+            _mockSupplyRecordDataAccess.Verify(x => x.GetSupplyRecordById(999), Times.Once);
+            _mockSupplyRecordDataAccess.Verify(x => x.SaveSupplyRecordToVehicle(It.IsAny<SupplyRecord>()), Times.Never);
+        }
+    }
+}

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,0 +1,94 @@
+# Tests
+
+This project contains unit tests for the CarCareTracker application using xUnit testing framework.
+
+## Test Structure
+
+The tests are organized by namespace and functionality:
+
+- **Logic/**: Tests for business logic classes
+  - `UserLogicTests.cs` - Tests for user management and access control
+  - `VehicleLogicTests.cs` - Tests for vehicle-related business logic
+  - `OdometerLogicTests.cs` - Tests for odometer record management
+  - `LoginLogicTests.cs` - Tests for authentication and user registration
+
+## Dependencies
+
+- **xUnit** - Testing framework
+- **Moq** - Mocking framework for dependencies
+- **Microsoft.NET.Test.Sdk** - Test SDK
+- **Microsoft.Extensions.Logging.Abstractions** - For logging interfaces
+- **Microsoft.Extensions.Caching.Memory** - For memory cache interfaces
+
+## Running Tests
+
+With .NET CLI:
+```bash
+dotnet test
+```
+
+With specific filter:
+```bash
+dotnet test --filter "FullyQualifiedName~UserLogicTests"
+```
+
+With coverage:
+```bash
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+With detailed output:
+```bash
+dotnet test --logger:"console;verbosity=detailed"
+```
+
+## Test Patterns
+
+### Mocking
+All tests use Moq to mock dependencies and isolate the units under test:
+
+```csharp
+private readonly Mock<IUserAccessDataAccess> _mockUserAccess;
+private readonly UserLogic _userLogic;
+
+public UserLogicTests()
+{
+    _mockUserAccess = new Mock<IUserAccessDataAccess>();
+    _userLogic = new UserLogic(_mockUserAccess.Object, ...);
+}
+```
+
+### Test Structure
+Tests follow the Arrange-Act-Assert pattern:
+
+```csharp
+[Fact]
+public void Method_Scenario_ExpectedResult()
+{
+    // Arrange
+    var input = new TestData();
+    _mockDependency.Setup(x => x.Method()).Returns(expectedValue);
+    
+    // Act
+    var result = _unitUnderTest.Method(input);
+    
+    // Assert
+    Assert.Equal(expectedValue, result);
+    _mockDependency.Verify(x => x.Method(), Times.Once);
+}
+```
+
+## Coverage
+
+The test suite covers:
+- ✅ **UserLogic** - Complete coverage of user access control methods
+- ✅ **VehicleLogic** - Coverage of vehicle record aggregation and calculations
+- ✅ **OdometerLogic** - Coverage of odometer record processing
+- ✅ **LoginLogic** - Coverage of authentication and user management
+
+## Future Improvements
+
+- Add integration tests for data access layers
+- Add controller tests with ASP.NET Core testing utilities
+- Add end-to-end tests for critical user workflows
+- Add performance tests for heavy calculation methods

--- a/Views/Vehicle/Index.cshtml
+++ b/Views/Vehicle/Index.cshtml
@@ -191,7 +191,7 @@
                     <label class="form-check-label" for="globalSearchAutoSearchCheck">@translator.Translate(userLanguage, "Incremental Search")</label>
                 </div>
                 <div class="form-check form-check-inline form-switch mt-1">
-                    <input class="form-check-input" type="checkbox" onChange="performGlobalSearch()" role="switch" id="globalSearchCaseSensitiveCheck" checked>
+                    <input class="form-check-input" type="checkbox" onChange="performGlobalSearch()" role="switch" id="globalSearchCaseSensitiveCheck" @(userConfig.UseDefaultCaseSensitiveSearch ? "checked" : "")>
                     <label class="form-check-label" for="globalSearchCaseSensitiveCheck">@translator.Translate(userLanguage, "Case Sensitive")</label>
                 </div>
                 <div id="globalSearchModalResults"></div>


### PR DESCRIPTION
### Description

Related to: https://github.com/hargata/lubelog/issues/1035

This PR adds functionality to use case-sensitive search for vehicle records. 

The default value is to use case-insensitive search.

### Note

This PR is created from the branch of PR #1031, which adds unit tests: https://github.com/hargata/lubelog/pull/1031

I wanted to utilize the existing tests and add some extra tests for the new feature.

For this reason, we have approximately 1,400 additional changes here that are related to PR #1031.

### Tests

Unit tests + tested in builded app in UI:

<img width="1440" height="256" alt="image" src="https://github.com/user-attachments/assets/bea86868-845f-4990-9480-48e343403230" />

#### Just search for test
<img width="804" height="229" alt="image" src="https://github.com/user-attachments/assets/c4ec4610-3c01-4db1-bd4e-ff260b741469" />

<img width="785" height="190" alt="image" src="https://github.com/user-attachments/assets/c90249cd-c370-4c40-9436-055fab1988ed" />

#### Search for TeSt

<img width="743" height="191" alt="image" src="https://github.com/user-attachments/assets/b3dddebe-6119-42ff-9208-ee8c932fd9f1" />

<img width="755" height="177" alt="image" src="https://github.com/user-attachments/assets/e247c477-33ba-4f3e-986c-5a5fae9d6719" />

Unit tests:
```
❯ dotnet test
  Determining projects to restore...
  All projects are up-to-date for restore.
  CarCareTracker -> /Users/lzima/Development/lubelog/bin/Debug/net8.0/CarCareTracker.dll
  CarCareTracker.Tests -> /Users/lzima/Development/lubelog/Tests/bin/Debug/net8.0/CarCareTracker.Tests.dll
Test run for /Users/lzima/Development/lubelog/Tests/bin/Debug/net8.0/CarCareTracker.Tests.dll (.NETCoreApp,Version=v8.0)
Microsoft (R) Test Execution Command Line Tool Version 17.8.0 (arm64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    84, Skipped:     0, Total:    84, Duration: 51 ms - CarCareTracker.Tests.dll (net8.0)
```

### Configuration

#### Case Sensitive Search

LubeLogger supports configurable case sensitivity for search operations across all record types.

**Environment Variable Configuration:**
```bash
LUBELOGGER_DEFAULT_CASE_SENSITIVE_SEARCH=true  # Enable case sensitive search by default
LUBELOGGER_DEFAULT_CASE_SENSITIVE_SEARCH=false # Disable case sensitive search by default (default)
```

**API Configuration:**
All search endpoints accept an optional `caseSensitive` parameter:
- `/Vehicle/{vehicleId}/SearchRecords?searchQuery={query}&caseSensitive=true`
- `/Vehicle/{vehicleId}/SearchRecordsByTags?tags={tags}&caseSensitive=false`

**UI Configuration:**
- **Global Search:** Use the case sensitivity checkbox in the search modal
- **User Preference:** Each user can set their default case sensitivity preference in their user configuration
- **Per-Search Override:** The checkbox setting overrides the user's default preference for that specific search

**Search Features:**
- **Text Search:** Full-text search across all record descriptions, notes, and content
- **Tag Search:** Search records by their associated tags
- **Multi-Record Support:** Search across service records, gas records, collision records, upgrades, taxes, supplies, odometer records, and notes
