### PR TITLE
[Proposal] Add event bus + example usage for Webhooks

### DIFF
--- a/.idea/.idea.CarCareTracker/.idea/.gitignore
+++ b/.idea/.idea.CarCareTracker/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/.idea.CarCareTracker.iml
+/modules.xml
+/projectSettingsUpdater.xml
+/contentModel.xml

--- a/.idea/.idea.CarCareTracker/.idea/.name
+++ b/.idea/.idea.CarCareTracker/.idea/.name
@@ -1,0 +1,1 @@
+CarCareTracker

--- a/.idea/.idea.CarCareTracker/.idea/indexLayout.xml
+++ b/.idea/.idea.CarCareTracker/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.CarCareTracker/.idea/vcs.xml
+++ b/.idea/.idea.CarCareTracker/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Events/VehicleAdded.cs
+++ b/Events/VehicleAdded.cs
@@ -1,0 +1,18 @@
+namespace CarCareTracker.Events;
+
+public class VehicleAdded
+{
+    public required string Identifier { get; init; }
+
+    public required string Make { get; init; }
+
+    public required string Model { get; init; }
+
+    public required int Year { get; init; }
+
+    public required int VehicleId { get; init; }
+
+    public required int UserId { get; init; }
+
+    public required string UserName { get; init; }
+}

--- a/Events/VehicleUpdated.cs
+++ b/Events/VehicleUpdated.cs
@@ -1,0 +1,18 @@
+namespace CarCareTracker.Events;
+
+public class VehicleUpdated
+{
+    public required string Identifier { get; init; }
+
+    public required string Make { get; init; }
+
+    public required string Model { get; init; }
+
+    public required int Year { get; init; }
+
+    public required int Id { get; init; }
+
+    public required int UserId { get; init; }
+
+    public required string UserName { get; init; }
+}

--- a/Helper/StaticHelper.cs
+++ b/Helper/StaticHelper.cs
@@ -440,24 +440,6 @@ namespace CarCareTracker.Helper
             }
         }
 
-        public static async Task NotifyAsyncV2(string webhookURL, WebHookPayload webHookPayload)
-        {
-            if (string.IsNullOrWhiteSpace(webhookURL))
-            {
-                return;
-            }
-            var httpClient = new HttpClient();
-            if (webhookURL.StartsWith("discord://"))
-            {
-                webhookURL = webhookURL.Replace("discord://", "https://"); //cleanurl
-                //format to discord
-                await httpClient.PostAsJsonAsync(webhookURL, DiscordWebHook.FromWebHookPayload(webHookPayload));
-            }
-            else
-            {
-                await httpClient.PostAsJsonAsync(webhookURL, webHookPayload);
-            }
-        }
         public static string GetImportModeIcon(ImportMode importMode)
         {
             switch (importMode)

--- a/Helper/StaticHelper.cs
+++ b/Helper/StaticHelper.cs
@@ -419,6 +419,8 @@ namespace CarCareTracker.Helper
                 }
             }
         }
+
+        [Obsolete("Prefer usages of IEventBus, and Webhook registration based on those events. See Program.cs AddWebhooks")]
         public static async void NotifyAsync(string webhookURL, WebHookPayload webHookPayload)
         {
             if (string.IsNullOrWhiteSpace(webhookURL))
@@ -435,6 +437,25 @@ namespace CarCareTracker.Helper
             else
             {
                 httpClient.PostAsJsonAsync(webhookURL, webHookPayload);
+            }
+        }
+
+        public static async Task NotifyAsyncV2(string webhookURL, WebHookPayload webHookPayload)
+        {
+            if (string.IsNullOrWhiteSpace(webhookURL))
+            {
+                return;
+            }
+            var httpClient = new HttpClient();
+            if (webhookURL.StartsWith("discord://"))
+            {
+                webhookURL = webhookURL.Replace("discord://", "https://"); //cleanurl
+                //format to discord
+                await httpClient.PostAsJsonAsync(webhookURL, DiscordWebHook.FromWebHookPayload(webHookPayload));
+            }
+            else
+            {
+                await httpClient.PostAsJsonAsync(webhookURL, webHookPayload);
             }
         }
         public static string GetImportModeIcon(ImportMode importMode)

--- a/Messaging/EventBus.cs
+++ b/Messaging/EventBus.cs
@@ -1,0 +1,188 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Threading.Channels;
+
+namespace CarCareTracker.Messaging;
+
+public sealed class EventBus : IEventBus
+{
+    private readonly Channel<object> _channel;
+    private readonly ILogger<EventBus>? _logger;
+    private readonly EventBusOptions _options;
+
+    private ImmutableDictionary<Type, ImmutableArray<Func<object, CancellationToken, Task>>> _handlers
+        = ImmutableDictionary<Type, ImmutableArray<Func<object, CancellationToken, Task>>>.Empty;
+
+    // For removals we need to know which wrapper we added.
+    private readonly ConcurrentDictionary<IDisposable, (Type type, Func<object, CancellationToken, Task> wrapper)> _subscriptions = new();
+
+    public EventBus(EventBusOptions? options = null, ILogger<EventBus>? logger = null)
+    {
+        _options = options ?? new EventBusOptions();
+        _logger = logger;
+
+        _channel = _options.BoundedCapacity is { } cap
+            ? Channel.CreateBounded<object>(new BoundedChannelOptions(cap)
+              {
+                  SingleReader = _options.SingleReader,
+                  SingleWriter = false,
+                  FullMode = BoundedChannelFullMode.Wait
+              })
+            : Channel.CreateUnbounded<object>(new UnboundedChannelOptions
+              {
+                  SingleReader = _options.SingleReader,
+                  SingleWriter = false
+              });
+    }
+
+    internal ChannelReader<object> Reader => _channel.Reader;
+
+    public Task Publish(object @event, CancellationToken ct = default)
+    {
+        if (@event is null) throw new ArgumentNullException(nameof(@event));
+        return _channel.Writer.WriteAsync(@event, ct).AsTask();
+    }
+
+    public void Publish(object @event)
+    {
+        if (@event is null) throw new ArgumentNullException(nameof(@event));
+        var written = _channel.Writer.TryWrite(@event);
+        if (!written && _options.ThrowOnSyncPublishWhenFull)
+        {
+            throw new InvalidOperationException("Event channel is full; use the async Publish overload to respect backpressure.");
+        }
+        // If not thrown and not written, the event is dropped by design.
+    }
+
+    public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler)
+    {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        // Wrap strongly-typed handler into an object-based one, with a fast cast.
+        Task Wrapper(object e, CancellationToken ct) => handler((TEvent)e, ct);
+
+        var type = typeof(TEvent);
+
+        ImmutableArray<Func<object, CancellationToken, Task>> original, updated;
+        do
+        {
+            original = _handlers.TryGetValue(type, out var arr) ? arr : ImmutableArray<Func<object, CancellationToken, Task>>.Empty;
+            updated = original.Add(Wrapper);
+        }
+        while (Interlocked.CompareExchange(
+                   ref _handlers,
+                   _handlers.SetItem(type, updated),
+                   _handlers) != _handlers);
+
+        var disposable = new Removal(this);
+        _subscriptions[disposable] = (type, Wrapper);
+        return disposable;
+    }
+
+    private sealed class Removal : IDisposable
+    {
+        private EventBus? _owner;
+        public Removal(EventBus owner) => _owner = owner;
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+
+            if (!owner._subscriptions.TryRemove(this, out var sub)) return;
+
+            var (type, wrapper) = sub;
+            ImmutableArray<Func<object, CancellationToken, Task>> updated;
+            do
+            {
+                if (!owner._handlers.TryGetValue(type, out var original))
+                    return;
+
+                var idx = original.IndexOf(wrapper);
+                if (idx < 0) return;
+
+                updated = original.RemoveAt(idx);
+            }
+            while (Interlocked.CompareExchange(
+                       ref owner._handlers,
+                       updated.Length == 0 ? owner._handlers.Remove(type) : owner._handlers.SetItem(type, updated),
+                       owner._handlers) != owner._handlers);
+        }
+    }
+
+    /// <summary>
+    /// Dispatch one event to all compatible handlers.
+    /// </summary>
+    internal async Task Dispatch(object @event, CancellationToken ct)
+    {
+        try
+        {
+            var evtType = @event.GetType();
+
+            // Collect handlers where subscribed type is assignable from the event type
+            // (i.e., subscribing to a base class or interface receives derived events).
+            var toInvoke = Array.Empty<Func<object, CancellationToken, Task>>();
+
+            foreach (var kvp in _handlers)
+            {
+                if (kvp.Key.IsAssignableFrom(evtType))
+                {
+                    // concatenate without allocations when possible
+                    var src = kvp.Value;
+                    if (toInvoke.Length == 0)
+                    {
+                        toInvoke = src.ToArray();
+                    }
+                    else
+                    {
+                        var tmp = new Func<object, CancellationToken, Task>[toInvoke.Length + src.Length];
+                        Array.Copy(toInvoke, 0, tmp, 0, toInvoke.Length);
+                        src.AsSpan().CopyTo(tmp.AsSpan(toInvoke.Length));
+                        toInvoke = tmp;
+                    }
+                }
+            }
+
+            if (toInvoke.Length == 0) return;
+
+            if (_options.PreserveHandlerOrder)
+            {
+                foreach (var h in toInvoke)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    try
+                    {
+                        await h(@event, ct);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogError(ex, "Event handler failed for {EventType}", evtType.FullName);
+                    }
+                }
+            }
+            else
+            {
+                var tasks = new Task[toInvoke.Length];
+                for (var i = 0; i < toInvoke.Length; i++)
+                {
+                    var h = toInvoke[i];
+                    tasks[i] = InvokeSafe(h, @event, ct);
+                }
+                await Task.WhenAll(tasks);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // normal during shutdown
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Unhandled exception while dispatching event {Event}", @event);
+        }
+    }
+
+    private async Task InvokeSafe(Func<object, CancellationToken, Task> h, object e, CancellationToken ct)
+    {
+        try { await h(e, ct); }
+        catch (Exception ex) { _logger?.LogError(ex, "Event handler failed for {EventType}", e.GetType().FullName); }
+    }
+}

--- a/Messaging/EventBusBackgroundService.cs
+++ b/Messaging/EventBusBackgroundService.cs
@@ -1,0 +1,37 @@
+namespace CarCareTracker.Messaging;
+
+public sealed class EventBusBackgroundService : BackgroundService
+{
+    private readonly EventBus _bus;
+    private readonly ILogger<EventBusBackgroundService>? _logger;
+
+    public EventBusBackgroundService(EventBus bus, ILogger<EventBusBackgroundService>? logger = null)
+    {
+        _bus = bus;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger?.LogInformation("EventBus background dispatcher starting");
+       
+        var reader = _bus.Reader;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            object next;
+            try
+            {
+                next = await reader.ReadAsync(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            await _bus.Dispatch(next, stoppingToken);
+        }
+
+        _logger?.LogInformation("EventBus background dispatcher stopping");
+    }
+}

--- a/Messaging/EventBusOptions.cs
+++ b/Messaging/EventBusOptions.cs
@@ -1,0 +1,25 @@
+namespace CarCareTracker.Messaging;
+
+public sealed class EventBusOptions
+{
+    /// <summary>
+    /// Null = unbounded channel; otherwise bounded to this capacity.
+    /// </summary>
+    public int? BoundedCapacity { get; set; }
+
+    /// <summary>
+    /// If true, handlers for a single event are awaited in sequence.
+    /// If false, handlers run concurrently (failures still logged individually).
+    /// </summary>
+    public bool PreserveHandlerOrder { get; set; } = true;
+
+    /// <summary>
+    /// If true, attempt single-reader optimizations.
+    /// </summary>
+    public bool SingleReader { get; set; } = true;
+
+    /// <summary>
+    /// If true and bounded, synchronous Publish() throws when the channel is full.
+    /// </summary>
+    public bool ThrowOnSyncPublishWhenFull { get; set; } = true;
+}

--- a/Messaging/EventBusServiceCollectionExtensions.cs
+++ b/Messaging/EventBusServiceCollectionExtensions.cs
@@ -1,0 +1,46 @@
+namespace CarCareTracker.Messaging;
+
+public static class EventBusServiceCollectionExtensions
+{
+    public static IEventBus AddEventBus(
+        this IServiceCollection services,
+        Action<EventBusOptions>? configure = null)
+    {
+        var opts = new EventBusOptions();
+        configure?.Invoke(opts);
+
+        services.AddSingleton(sp =>
+        {
+            var logger = sp.GetService<ILogger<EventBus>>();
+            return new EventBus(opts, logger);
+        });
+
+        services.AddHostedService(sp =>
+        {
+            var bus = (EventBus)sp.GetRequiredService<EventBus>();
+            var logger = sp.GetService<ILogger<EventBusBackgroundService>>();
+            return new EventBusBackgroundService(bus, logger);
+        });
+
+        services.AddSingleton<IEventBus>(sp => sp.GetRequiredService<EventBus>());
+
+        // ⚠️ Important: we can't return the actual instance yet, because DI container is not built.
+        // Instead, return a proxy that resolves lazily.
+        return new DeferredEventBus(services);
+    }
+
+    private sealed class DeferredEventBus : IEventBus
+    {
+        private readonly IServiceCollection _services;
+        private IServiceProvider? _provider;
+        private IEventBus Bus => (_provider ??= _services.BuildServiceProvider()).GetRequiredService<IEventBus>();
+
+        public DeferredEventBus(IServiceCollection services) => _services = services;
+
+        public Task Publish(object @event, CancellationToken ct = default) => Bus.Publish(@event, ct);
+
+        public void Publish(object @event) => Bus.Publish(@event);
+
+        public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler) => Bus.Subscribe(handler);
+    }
+}

--- a/Messaging/IEventBus.cs
+++ b/Messaging/IEventBus.cs
@@ -1,0 +1,10 @@
+namespace CarCareTracker.Messaging;
+
+public interface IEventBus
+{
+    Task Publish(object @event, CancellationToken ct = default);
+
+    void Publish(object @event);
+
+    IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler);
+}

--- a/Webhooks/IWebhookPublisher.cs
+++ b/Webhooks/IWebhookPublisher.cs
@@ -1,0 +1,8 @@
+using CarCareTracker.Models;
+
+namespace CarCareTracker.Webhooks;
+
+public interface IWebhookPublisher
+{
+    Task PublishAsync(WebHookPayloadBase payload, CancellationToken ct = default);
+}

--- a/Webhooks/WebhookExtensions.cs
+++ b/Webhooks/WebhookExtensions.cs
@@ -1,0 +1,73 @@
+using CarCareTracker.Messaging;
+using CarCareTracker.Models;
+
+namespace CarCareTracker.Webhooks;
+
+public static class WebhookExtensions
+{
+    // Register mappings (no resolution here)
+    public static IServiceCollection AddWebhooks(this IServiceCollection services, Action<WebhookMap> configure)
+    {
+        if (configure is null) throw new ArgumentNullException(nameof(configure));
+
+        // single registry instance that stores the map actions
+        var registry = new WebhookRegistry();
+        configure(new WebhookMap(registry));
+
+        services.AddSingleton(registry);
+        return services;
+    }
+
+    public static WebApplication UseWebhooks(this WebApplication app)
+    {
+        var sp = app.Services;
+        var bus = sp.GetRequiredService<IEventBus>();
+        var registry = sp.GetRequiredService<WebhookRegistry>();
+
+        var subs = new List<IDisposable>();
+        foreach (var r in registry.Items)
+        {
+            // returns the IDisposable subscription
+            var sub = r(sp, bus);
+            subs.Add(sub);
+        }
+
+        return app;
+    }
+}
+
+// Simple in-memory registry of “how to subscribe”
+public sealed class WebhookRegistry
+{
+    private readonly List<Func<IServiceProvider, IEventBus, IDisposable>> _items = new();
+    internal IEnumerable<Func<IServiceProvider, IEventBus, IDisposable>> Items => _items;
+
+    internal void Add(Func<IServiceProvider, IEventBus, IDisposable> reg) => _items.Add(reg);
+}
+
+// Fluent map that records Register<T> calls
+public sealed class WebhookMap
+{
+    private readonly WebhookRegistry _registry;
+    public WebhookMap(WebhookRegistry registry) => _registry = registry;
+
+    public WebhookMap Register<TEvent>(Func<TEvent, WebHookPayload> toPayload)
+    {
+        if (toPayload is null) throw new ArgumentNullException(nameof(toPayload));
+
+        _registry.Add((sp, bus) =>
+        {
+            // Subscribe now (at UseWebhooks time). Per event we resolve IWebhookPublisher from a fresh scope.
+            return bus.Subscribe<TEvent>(async (e, ct) =>
+            {
+                using var scope = sp.CreateScope();
+                var publisher = scope.ServiceProvider.GetRequiredService<IWebhookPublisher>();
+
+                var payload = toPayload(e);
+                await publisher.PublishAsync(payload, ct);
+            });
+        });
+
+        return this;
+    }
+}

--- a/Webhooks/WebhookPublisher.cs
+++ b/Webhooks/WebhookPublisher.cs
@@ -7,15 +7,19 @@ public class WebhookPublisher : IWebhookPublisher
 {
     private readonly IConfigHelper _config;
     private readonly HttpClient _client;
+    private readonly ILogger<WebhookPublisher> _logger;
 
-    public WebhookPublisher(IConfigHelper config)
+    public WebhookPublisher(IConfigHelper config, ILogger<WebhookPublisher> logger)
     {
         _config = config;
+        _logger = logger;
         _client = new HttpClient();
     }
 
     public async Task PublishAsync(WebHookPayloadBase payload, CancellationToken ct = default)
     {
+        this._logger.LogInformation("Publishing webhook payload");
+
         await _client.PostAsJsonAsync(_config.GetWebHookUrl(), payload, ct);
     }
 }

--- a/Webhooks/WebhookPublisher.cs
+++ b/Webhooks/WebhookPublisher.cs
@@ -1,0 +1,21 @@
+using CarCareTracker.Helper;
+using CarCareTracker.Models;
+
+namespace CarCareTracker.Webhooks;
+
+public class WebhookPublisher : IWebhookPublisher
+{
+    private readonly IConfigHelper _config;
+    private readonly HttpClient _client;
+
+    public WebhookPublisher(IConfigHelper config)
+    {
+        _config = config;
+        _client = new HttpClient();
+    }
+
+    public async Task PublishAsync(WebHookPayloadBase payload, CancellationToken ct = default)
+    {
+        await _client.PostAsJsonAsync(_config.GetWebHookUrl(), payload, ct);
+    }
+}


### PR DESCRIPTION
## What's this?

Firstly, hey all 👋 

This is more of a proposal/example of using an event based pattern internally

Instead of directly publishing Webhooks, move to an Event model. Then subscribe to these events to send Webhooks etc. This would allow for multiple subscribers for the same event, e.g. Webhook + Discord + Push Messaging

## Considerations

In-memory only, with a simple Channel based EventBus (no Rabbit/Masstransit etc for simplicity)