### PR TITLE
Update docker-compose.traefik.yml

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -25,13 +25,13 @@ services:
       # define network for traefik<>app communication
       traefik.docker.network: traefik-ingress
       ## HTTP Routers
-      traefik.http.routers.whoami.entrypoints: https
-      traefik.http.routers.whoami.rule: Host(`lubelog.mydomain.tld`)
+      traefik.http.routers.lubelogger.entrypoints: https
+      traefik.http.routers.lubelogger.rule: Host(`lubelog.mydomain.tld`)
       ## Middlewares
-      #traefik.http.routers.whoami.middlewares: authentik@docker
+      #traefik.http.routers.lubelogger.middlewares: authentik@docker
       # none
       ## HTTP Services
-      traefik.http.services.whoami.loadbalancer.server.port: 5000
+      traefik.http.services.lubelogger.loadbalancer.server.port: 8080
 
 volumes:
   data:


### PR DESCRIPTION
Looking at the Docker Compose example for Traefik, I noticed an error, and a couple objectively incorrect strings, in the Traefik labels: the service definition used the incorrect port, and the service & router names reference an example whoami service instead of lubelogger. This small PR addresses this, hopefully making integration clearer to potential users who are newer to Traefik.