### PR TITLE
Optional: Force Fuel Mileage chart to display km/l when source unit is l/100km

### DIFF
--- a/Controllers/Vehicle/ReportController.cs
+++ b/Controllers/Vehicle/ReportController.cs
@@ -138,7 +138,9 @@ namespace CarCareTracker.Controllers
                 MonthName = CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(x.Key),
                 Cost = x.Sum(y => y.Cost)
             }).ToList();
-            if (invertedFuelMileageUnit)
+            // If the vehicle's base fuel economy unit is l/100km and the user has opted
+            // to force the chart to km/l, convert the monthly values to km/l.
+            if (fuelEconomyMileageUnit == "l/100km" && userConfig.ForceKmPerLForChart)
             {
                 foreach (CostForVehicleByMonth monthMileage in monthlyMileageData)
                 {
@@ -147,16 +149,20 @@ namespace CarCareTracker.Controllers
                         monthMileage.Cost = 100 / monthMileage.Cost;
                     }
                 }
+                // Also convert the average MPG display value so header matches chart units
                 var newAverageMPG = decimal.Parse(averageMPG, NumberStyles.Any);
                 if (newAverageMPG != 0)
                 {
                     newAverageMPG = 100 / newAverageMPG;
                 }
                 averageMPG = newAverageMPG.ToString("F");
+                // ensure sorting and unit label reflect the converted display
+                invertedFuelMileageUnit = true;
             }
+            var displayUnit = (fuelEconomyMileageUnit == "l/100km" && userConfig.ForceKmPerLForChart) ? "km/l" : (invertedFuelMileageUnit ? preferredFuelMileageUnit : fuelEconomyMileageUnit);
             var mpgViewModel = new MPGForVehicleByMonth {
                 CostData = monthlyMileageData,
-                Unit = invertedFuelMileageUnit ? preferredFuelMileageUnit : fuelEconomyMileageUnit,
+                Unit = displayUnit,
                 SortedCostData = (userConfig.UseMPG || invertedFuelMileageUnit) ? monthlyMileageData.OrderByDescending(x => x.Cost).ToList() : monthlyMileageData.OrderBy(x => x.Cost).ToList()
             };
             viewModel.FuelMileageForVehicleByMonth = mpgViewModel;

--- a/Helper/ConfigHelper.cs
+++ b/Helper/ConfigHelper.cs
@@ -393,7 +393,8 @@ namespace CarCareTracker.Helper
                 UserColumnPreferences = _config.GetSection(nameof(UserConfig.UserColumnPreferences)).Get<List<UserColumnPreference>>() ?? new List<UserColumnPreference>(),
                 DefaultTab = (ImportMode)int.Parse(CheckString(nameof(UserConfig.DefaultTab), "8")),
                 ShowVehicleThumbnail = CheckBool(CheckString(nameof(UserConfig.ShowVehicleThumbnail))),
-                ShowSearch = CheckBool(CheckString(nameof(UserConfig.ShowSearch)))
+                ShowSearch = CheckBool(CheckString(nameof(UserConfig.ShowSearch))),
+                ForceKmPerLForChart = CheckBool(CheckString(nameof(UserConfig.ForceKmPerLForChart)))
             };
             int userId = 0;
             if (user != null)

--- a/Models/UserConfig.cs
+++ b/Models/UserConfig.cs
@@ -53,5 +53,8 @@
             ImportMode.NoteRecord,
             ImportMode.ReminderRecord
         };
+        // When true, force dashboard Fuel Mileage by Month chart to display km/l
+        // when the vehicle's base unit is l/100km.
+        public bool ForceKmPerLForChart { get; set; } = false;
     }
 }

--- a/Views/Home/_Settings.cshtml
+++ b/Views/Home/_Settings.cshtml
@@ -86,6 +86,10 @@
         </div>
         <hr />
         <div class="form-check form-switch">
+            <input class="form-check-input" onChange="updateSettings()" type="checkbox" role="switch" id="forceKmPerLForChart" checked="@Model.UserConfig.ForceKmPerLForChart">
+            <label class="form-check-label" for="forceKmPerLForChart">@translator.Translate(userLanguage, "Show Fuel Mileage Chart as km/l instead of l/100km")</label>
+        </div>
+        <div class="form-check form-switch">
             <input class="form-check-input" onChange="updateSettings()" type="checkbox" role="switch" id="enableAutoReminderRefresh" checked="@Model.UserConfig.EnableAutoReminderRefresh">
             <label class="form-check-label" for="enableAutoReminderRefresh">@translator.Translate(userLanguage, "Auto Refresh Lapsed Recurring Reminders")</label>
         </div>

--- a/wwwroot/js/settings.js
+++ b/wwwroot/js/settings.js
@@ -66,6 +66,7 @@ function updateSettings() {
         preferredGasUnit: $("#preferredGasUnit").val(),
         preferredGasMileageUnit: $("#preferredFuelMileageUnit").val(),
         userLanguage: $("#defaultLanguage").val(),
+        forceKmPerLForChart: $("#forceKmPerLForChart").is(":checked"),
         useUnitForFuelCost: $("#useUnitForFuelCost").is(":checked"),
         visibleTabs: visibleTabs,
         defaultTab: defaultTab,


### PR DESCRIPTION
Add user setting to optionally force the Fuel Mileage by Month chart to display km/l when the vehicle's source unit is l/100km.\n\nFiles changed:\n- Models/UserConfig.cs\n- Helper/ConfigHelper.cs\n- Views/Home/_Settings.cshtml\n- wwwroot/js/settings.js\n- Controllers/Vehicle/ReportController.cs\n\nHow to test:\n1. Build and run the app (via Docker): sudo docker build -t lubelog:local -f Dockerfile . && docker run --rm -p 8080:8080 -e ASPNETCORE_URLS="http://+:8080" lubelog:local\n2. In Settings enable the new setting and save.\n3. Check Dashboard for a vehicle with l/100km data and verify the chart shows km/l.