### PR TITLE
feat: Add HealthCheck binary for docker

### DIFF
--- a/CarCareTracker.csproj
+++ b/CarCareTracker.csproj
@@ -11,6 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="HealthCheck\**" />
+    <Content Remove="HealthCheck\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="LiteDB" Version="5.0.17" />
     <PackageReference Include="MailKit" Version="4.14.1" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,14 @@ WORKDIR /App
 
 COPY . ./
 ARG TARGETARCH
-RUN dotnet restore -a $TARGETARCH
-RUN dotnet publish -a $TARGETARCH -c Release -o out
+RUN dotnet restore CarCareTracker.csproj -a $TARGETARCH
+RUN dotnet publish CarCareTracker.csproj -a $TARGETARCH -c Release -o out
+RUN dotnet publish HealthCheck/HealthCheck.csproj -a $TARGETARCH -c Release -o out/healthcheck
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /App
 COPY --from=build-env /App/out .
 EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+  CMD /App/healthcheck/HealthCheck || exit 1
 CMD ["./CarCareTracker"]

--- a/HealthCheck/HealthCheck.csproj
+++ b/HealthCheck/HealthCheck.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/HealthCheck/Program.cs
+++ b/HealthCheck/Program.cs
@@ -1,0 +1,10 @@
+using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+try
+{
+    var response = await client.GetAsync("http://localhost:8080/health");
+    return response.IsSuccessStatusCode ? 0 : 1;
+}
+catch
+{
+    return 1;
+}

--- a/Program.cs
+++ b/Program.cs
@@ -115,6 +115,7 @@ builder.Services.AddAuthorization(options =>
 {
     options.DefaultPolicy = new AuthorizationPolicyBuilder().AddAuthenticationSchemes("AuthN").RequireAuthenticatedUser().Build();
 });
+builder.Services.AddHealthChecks();
 //Configure max file upload size
 builder.Services.Configure<KestrelServerOptions>(options =>
 {
@@ -198,5 +199,7 @@ app.UseAuthorization();
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
+
+app.MapHealthChecks("/health").AllowAnonymous();
 
 app.Run();


### PR DESCRIPTION
Simple program that can be invoked by the Dockerfile to determine the health of the container.

Originally I was going to add curl/wget to the Dockerfile, but I know that's excluded on purpose in the original aspnet:8.0 container due to additional security vulnerabilities that could be used. So instead I created a tiny program using .net to query the added health check within the main application.

Addresses #932 