### PR TITLE
Fix API to include equipped items when adding odometer record (#1231)

### DIFF
--- a/Controllers/API/OdometerController.cs
+++ b/Controllers/API/OdometerController.cs
@@ -186,6 +186,16 @@ namespace CarCareTracker.Controllers
                     return Json(OperationResponse.Failed($"Input object invalid, equipment with ids {string.Join(' ', invalidEquipmentRecordIds)} does not exist."));
                 }
             }
+            else
+            {
+                // Auto include equipment marked as currently equipped for vehicle
+                var equipmentRecords = _equipmentRecordDataAccess.GetEquipmentRecordsByVehicleId(vehicleId);
+                var equippedEquipment = equipmentRecords.Where(x => x.IsEquipped);
+                if (equippedEquipment.Any())
+                {
+                    equipmentRecordId = equippedEquipment.Select(x => x.Id).ToList();
+                }
+            }
             try
             {
                 var odometerRecord = new OdometerRecord()


### PR DESCRIPTION
When adding an odometer record via /api/vehicle/odometerrecords/add without specifying EquipmentRecordId this PR includes a fix to automatically include any equipment that is marked as IsEquipped=true for that vehicle - matching the UI behavior.