### PR TITLE
Planner redesign with modern look and feel

### DIFF
--- a/Helper/StaticHelper.cs
+++ b/Helper/StaticHelper.cs
@@ -84,11 +84,26 @@ namespace CarCareTracker.Helper
                 case PlanPriority.Critical:
                     return "text-bg-danger";
                 case PlanPriority.Normal:
-                    return "text-bg-primary";
+                    return "text-bg-warning";
                 case PlanPriority.Low:
-                    return "text-bg-info";
+                    return "text-bg-primary";
                 default:
                     return "text-bg-primary";
+            }
+        }
+
+        public static string GetPlanRecordTextColor(PlanPriority input)
+        {
+            switch (input)
+            {
+                case PlanPriority.Critical:
+                    return "text-danger";
+                case PlanPriority.Normal:
+                    return "text-warning";
+                case PlanPriority.Low:
+                    return "text-primary";
+                default:
+                    return "text-primary";
             }
         }
 
@@ -107,6 +122,35 @@ namespace CarCareTracker.Helper
                 default:
                     return input.ToString();
             }
+        }
+
+        public static List<BoardColumn> GetBoardColumnsWithUserPreferences(UserConfig userConfig)
+        {
+            var userColumnPreference = userConfig.UserColumnPreferences
+                .FirstOrDefault(x => x.Tab == ImportMode.PlanRecord)
+                ?? new UserColumnPreference
+                {
+                    Tab = ImportMode.PlanRecord,
+                    VisibleColumns = Enum.GetNames<PlanProgress>().ToList(),
+                    ColumnOrder = Enum.GetNames<PlanProgress>().ToList()
+                };
+
+            var boardColumns = Enum.GetValues<PlanProgress>()
+                .Select(planProgress =>
+                {
+                    var name = planProgress.ToString();
+                    return new BoardColumn
+                    {
+                        Name = GetPlanRecordProgress(planProgress),
+                        Progress = planProgress,
+                        Visible = userColumnPreference.VisibleColumns.Contains(name),
+                        Order = userColumnPreference.ColumnOrder.IndexOf(name)
+                    };
+                })
+                .OrderBy(x => x.Order)
+                .ToList();
+
+            return boardColumns;
         }
 
         public static string TruncateStrings(string input, int maxLength = 25)
@@ -457,6 +501,22 @@ namespace CarCareTracker.Helper
                     return "bi-disc";
                 default:
                     return "bi-file-bar-graph";
+            }
+        }
+        public static string GetPlannerColumnIcon(PlanProgress planProgress)
+        {
+            switch (planProgress)
+            {
+                case PlanProgress.Backlog:
+                    return "bi-list-task";
+                case PlanProgress.InProgress:
+                    return "bi-tools";
+                case PlanProgress.Testing:
+                    return "bi-eyeglasses";
+                case PlanProgress.Done:
+                    return "bi-check2-all";
+                default:
+                    return "bi-list-task";
             }
         }
         public static string GetVehicleIdentifier(Vehicle vehicle)

--- a/Models/PlanRecord/BoardColumn.cs
+++ b/Models/PlanRecord/BoardColumn.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace CarCareTracker.Models
+{
+    public class BoardColumn
+    {
+        public string Name { get; set; } = string.Empty;
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public PlanProgress Progress { get; set; }
+        public bool Visible { get; set; }
+        public int Order { get; set; }
+    }
+}

--- a/Views/Vehicle/Plan/_PlanRecordItem.cshtml
+++ b/Views/Vehicle/Plan/_PlanRecordItem.cshtml
@@ -1,61 +1,73 @@
 ﻿@using CarCareTracker.Helper
 @inject IConfigHelper config
+@inject ITranslationHelper translator
 @{
     var userConfig = config.GetUserConfig(User);
     var hideZero = userConfig.HideZero;
+    var userLanguage = userConfig.UserLanguage;
 }
 @model PlanRecord
-<div class="taskCard @(Model.Progress == PlanProgress.Done ? "nodrag" : "") text-dark user-select-none mt-2 mb-2" draggable="@(Model.Progress == PlanProgress.Done ? "false" : "true")" ondragstart="dragStart(event, @Model.Id)" onclick="@(Model.Progress == PlanProgress.Done ? $"deletePlanRecord({Model.Id}, true)" : $"showEditPlanRecordModal({Model.Id})")" oncontextmenu="@($"showPlanTableContextMenu(this, {Model.Id}, '{Model.Progress}')")" onmouseup="stopEvent()" ontouchstart="detectPlanItemLongTouch(this, @Model.Id, '@Model.Progress')" ontouchend="detectPlanItemTouchEndPremature(this)">
+
+<div class="task-card @(Model.Progress == PlanProgress.Done ? "nodrag opacity-50" : "") user-select-none mx-1 mt-3" 
+     draggable="@(Model.Progress == PlanProgress.Done ? "false" : "true")" 
+     ondragstart="dragStart(event, @Model.Id)" 
+     onclick="@(Model.Progress == PlanProgress.Done ? $"deletePlanRecord({Model.Id}, true)" : $"showEditPlanRecordModal({Model.Id})")" 
+     oncontextmenu="@($"showPlanTableContextMenu(this, {Model.Id}, '{Model.Progress}')")"
+     onmouseup="stopEvent()" ontouchstart="detectPlanItemLongTouch(this, @Model.Id, '@Model.Progress')" 
+     ontouchend="detectPlanItemTouchEndPremature(this)">
     <div class="card-body">
         <div class="row">
-            <div class="col-12 col-lg-8 text-truncate">
-                @if (Model.Progress == PlanProgress.Done)
-                {
-                    <span class="taskCard-title text-truncate"><s>@Model.Description</s></span>
-                } else
-                {
-                    <span class="taskCard-title text-truncate">@Model.Description</span>
-                }
-            </div>
-            <div class="col-12 col-lg-4 d-flex align-items-center">
-                <span class="text-truncate">@(StaticHelper.HideZeroCost(Model.Cost, hideZero))</span>
+            <div class="col-12 mb-1">
+                <div class="title-container">
+                    @if (Model.Priority == PlanPriority.Critical)
+                    {
+                        <span class="float-end badge @StaticHelper.GetPlanRecordTextColor(PlanPriority.Critical) @StaticHelper.GetPlanRecordColor(PlanPriority.Critical) bg-opacity-10 " title="@translator.Translate(userLanguage, "Priority") @translator.Translate(userLanguage, "Critical")"> @translator.Translate(userLanguage, "Critical")</span>
+                    }
+                    else if (Model.Priority == PlanPriority.Normal)
+                    {
+                        <span class="float-end badge @StaticHelper.GetPlanRecordTextColor(PlanPriority.Normal) @StaticHelper.GetPlanRecordColor(PlanPriority.Normal) bg-opacity-10 " title="@translator.Translate(userLanguage, "Priority") @translator.Translate(userLanguage, "Normal")"> @translator.Translate(userLanguage, "Normal")</span>
+                    }
+                    else if (Model.Priority == PlanPriority.Low)
+                    {
+                        <span class="float-end badge @StaticHelper.GetPlanRecordTextColor(PlanPriority.Low) @StaticHelper.GetPlanRecordColor(PlanPriority.Low) bg-opacity-10 " title="@translator.Translate(userLanguage, "Priority") @translator.Translate(userLanguage, "Low")"> @translator.Translate(userLanguage, "Low")</span>
+                    }
+                    @if (Model.ReminderRecordId != default)
+                    {
+                        <span class="px-1" title="@translator.Translate(userLanguage,"Reminder")"><i class="bi bi-bell-fill text-warning"></i></span>
+                    }
+                    @if (Model.Progress == PlanProgress.Done)
+                    {
+                        <span class="task-card-title"><s>@Model.Description</s></span>
+                    } else
+                    {
+                        <span class="task-card-title">@Model.Description</span>
+                    }
+                </div>
             </div>
         </div>
         <div class="row">
-            @if (Model.ReminderRecordId != default)
-            {
-                <div class="col-3 col-md-1">
-                    <span class="badge text-bg-light planner-indicator"><i class="bi bi-bell-fill text-warning"></i></span>
-                </div>
-            }
-            <div class="@(Model.ReminderRecordId != default ? "col-3" : "col-6") col-md-1">
+            <div class="col-6">
                 @if (Model.ImportMode == ImportMode.ServiceRecord)
                 {
-                    <span class="badge text-bg-primary planner-indicator"><i class="bi bi-card-checklist text-white"></i></span>
+                    <span class="badge text-bg-primary" title="@translator.Translate(userLanguage,"Service")"><i class="bi bi-card-checklist text-white"></i> @translator.Translate(userLanguage,"Service")</span>
                 }
                 else if (Model.ImportMode == ImportMode.UpgradeRecord)
                 {
-                    <span class="badge text-bg-success planner-indicator"><i class="bi bi-wrench-adjustable text-white"></i></span>
+                    <span class="badge text-bg-success" title="@translator.Translate(userLanguage,"Upgrade")"><i class="bi bi-wrench-adjustable text-white"></i> @translator.Translate(userLanguage,"Upgrade")</span>
                 }
                 else if (Model.ImportMode == ImportMode.RepairRecord)
                 {
-                    <span class="badge text-bg-warning planner-indicator"><i class="bi bi-exclamation-octagon text-white"></i></span>
+                    <span class="badge text-bg-danger" title="@translator.Translate(userLanguage,"Repair")"><i class="bi bi-exclamation-octagon text-white"></i> @translator.Translate(userLanguage,"Repair")</span>
                 }
+            </div>              
+            <div class="col-6 d-flex justify-content-end ">
+                <span class="badge text-secondary"> @(StaticHelper.HideZeroCost(Model.Cost, hideZero))</span>
             </div>
-            <div class="@(Model.ReminderRecordId != default ? "col-3" : "col-6") col-md-1">
-                @if (Model.Priority == PlanPriority.Critical)
-                {
-                    <span class="badge text-bg-danger planner-indicator"><i class="bi bi-fire text-white"></i></span>
-                }
-                else if (Model.Priority == PlanPriority.Normal)
-                {
-                    <span class="badge text-bg-primary planner-indicator"><i class="bi bi-water text-white"></i></span>
-                }
-                else if (Model.Priority == PlanPriority.Low)
-                {
-                    <span class="badge text-bg-info planner-indicator"><i class="bi bi-snow text-white"></i></span>
-                }
-            </div>
+        </div>        
+        <div class="row">
+            <div class="col-12 hideOnPrint flex-grow-1 flex-shrink-1 text-secondary small mt-1">@StaticHelper.TruncateStrings(@Model.Notes, 100)</div>
+            <div id="markdown-@Model.Id" class="col-12 showOnPrint text-secondary mt-1">@Model.Notes</div>
+
         </div>
     </div>
 </div>

--- a/Views/Vehicle/Plan/_PlanRecordModal.cshtml
+++ b/Views/Vehicle/Plan/_PlanRecordModal.cshtml
@@ -6,6 +6,9 @@
     var isNew = Model.Id == 0;
     var userConfig = config.GetUserConfig(User);
     var userLanguage = userConfig.UserLanguage;
+    var boardColumns = StaticHelper.GetBoardColumnsWithUserPreferences(userConfig)
+        .Where(x => x.Progress != PlanProgress.Done)
+        .ToList();
 }
 <div class="modal-header">
     <h5 class="modal-title">@(isNew ? translator.Translate(userLanguage, "Add New Plan Record") : translator.Translate(userLanguage, "Edit Plan Record"))<small style="display:none; @(isNew ? "" : "cursor:pointer;")" class="cached-banner ms-2 text-warning" onclick='@(isNew ? "" : $"showEditPlanRecordModal({Model.Id}, true)" )'>@translator.Translate(userLanguage, "Unsaved Changes")</small></h5>
@@ -34,11 +37,13 @@
                         <!option value="Normal" @(Model.Priority == PlanPriority.Normal || isNew ? "selected" : "")>@translator.Translate(userLanguage, "Normal")</!option>
                         <!option value="Low" @(Model.Priority == PlanPriority.Low ? "selected" : "")>@translator.Translate(userLanguage, "Low")</!option>
                     </select>
-                    <label for="planRecordProgress">@translator.Translate(userLanguage, "Current Stage")</label>
+                    <label for="planRecordProgress">@translator.Translate(userLanguage, "Current Board")</label>
                     <select class="form-select" id="planRecordProgress">
-                        <!option value = "Backlog" @(Model.Progress == PlanProgress.Backlog || isNew ? "selected" : "")>@translator.Translate(userLanguage, "Planned")</!option>
-                        <!option value="InProgress" @(Model.Progress == PlanProgress.InProgress ? "selected" : "")>@translator.Translate(userLanguage, "Doing")</!option>
-                        <!option value = "Testing" @(Model.Progress == PlanProgress.Testing ? "selected" : "")>@translator.Translate(userLanguage, "Testing")</!option>
+                        @foreach (var column in boardColumns)
+                        {
+                            var isSelected = (Model.Progress == column.Progress) || (isNew && column.Progress == PlanProgress.Backlog);
+                            <!option value="@column.Progress" @(isSelected ? "selected" : "")>@translator.Translate(userLanguage, column.Name)</!option>
+                        }
                     </select>
                     @await Html.PartialAsync("_ExtraField", Model.ExtraFields)
                     @if (!isNew)

--- a/Views/Vehicle/Plan/_PlanRecordTemplateEditModal.cshtml
+++ b/Views/Vehicle/Plan/_PlanRecordTemplateEditModal.cshtml
@@ -6,6 +6,9 @@
     var isNew = Model.Id == 0;
     var userConfig = config.GetUserConfig(User);
     var userLanguage = userConfig.UserLanguage;
+    var boardColumns = StaticHelper.GetBoardColumnsWithUserPreferences(userConfig)
+        .Where(x => x.Progress != PlanProgress.Done)
+        .ToList();
 }
 <div class="modal-header">
     <h5 class="modal-title">@translator.Translate(userLanguage, "Edit Plan Record Template")<small style="display:none; @(isNew ? "" : "cursor:pointer;")" class="cached-banner ms-2 text-warning" onclick='@(isNew ? "" : $"showEditPlanRecordTemplateModal({Model.Id}, true)" )'>@translator.Translate(userLanguage, "Unsaved Changes")</small></h5>
@@ -34,11 +37,13 @@
                         <!option value="Normal" @(Model.Priority == PlanPriority.Normal || isNew ? "selected" : "")>@translator.Translate(userLanguage, "Normal")</!option>
                         <!option value="Low" @(Model.Priority == PlanPriority.Low ? "selected" : "")>@translator.Translate(userLanguage, "Low")</!option>
                     </select>
-                    <label for="planRecordProgress">@translator.Translate(userLanguage, "Current Stage")</label>
+                    <label for="planRecordProgress">@translator.Translate(userLanguage, "Current Board")</label>
                     <select class="form-select" id="planRecordProgress">
-                        <!option value = "Backlog" @(Model.Progress == PlanProgress.Backlog || isNew ? "selected" : "")>@translator.Translate(userLanguage, "Planned")</!option>
-                        <!option value="InProgress" @(Model.Progress == PlanProgress.InProgress ? "selected" : "")>@translator.Translate(userLanguage, "Doing")</!option>
-                        <!option value = "Testing" @(Model.Progress == PlanProgress.Testing ? "selected" : "")>@translator.Translate(userLanguage, "Testing")</!option>
+                        @foreach (var column in boardColumns)
+                        {
+                            var isSelected = (Model.Progress == column.Progress) || (isNew && column.Progress == PlanProgress.Backlog);
+                            <!option value="@column.Progress" @(isSelected ? "selected" : "")>@translator.Translate(userLanguage, column.Name)</!option>
+                        }
                     </select>
                     @await Html.PartialAsync("_ExtraField", Model.ExtraFields)
                 </div>

--- a/Views/Vehicle/Plan/_PlanRecords.cshtml
+++ b/Views/Vehicle/Plan/_PlanRecords.cshtml
@@ -6,11 +6,9 @@
     var enableCsvImports = userConfig.EnableCsvImports;
     var hideZero = userConfig.HideZero;
     var userLanguage = userConfig.UserLanguage;
-    var backLogItems = Model.Where(x => x.Progress == PlanProgress.Backlog).OrderBy(x=>x.Priority);
-    var inProgressItems = Model.Where(x => x.Progress == PlanProgress.InProgress).OrderBy(x => x.Priority);
-    var testingItems = Model.Where(x => x.Progress == PlanProgress.Testing).OrderBy(x => x.Priority);
-    var doneItems = Model.Where(x => x.Progress == PlanProgress.Done).OrderBy(x => x.Priority);
     var autoFillOdometer = userConfig.EnableAutoFillOdometer;
+    var userColumnPreferences = userConfig.UserColumnPreferences.Where(x=>x.Tab == ImportMode.PlanRecord);
+    var boardColumns = StaticHelper.GetBoardColumnsWithUserPreferences(userConfig);
 }
 @model List<PlanRecord>
 <div class="d-flex flex-column vehicleTabPane">
@@ -32,6 +30,26 @@
                         <li><a class="dropdown-item" href="#" onclick="exportVehicleData('PlanRecord')">@translator.Translate(userLanguage,"Export to CSV")</a></li>
                         <li class="nav-no-copy"><hr class="dropdown-divider"></li>
                         <li class="nav-no-copy"><a class="dropdown-item" href="#" onclick="showPlanRecordTemplatesModal()">@translator.Translate(userLanguage, "View Templates")</a></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><h6 class="dropdown-header">@translator.Translate(userLanguage, "Visible Boards")</h6></li>
+                        @foreach (var column in boardColumns)
+                        {
+                            <li class="dropdown-item" draggable="true"
+                                ondragstart="handleTableColumnDragStart(event)"
+                                ondragover="handleTableColumnDragOver(event)"
+                                ondragend="handleTableColumnDragEnd('PlanRecord')">
+                                <div class="list-group-item">
+                                    <input class="form-check-input col-visible-toggle"
+                                           data-column-toggle='@column.Progress'
+                                           onChange="showTableColumns(this, 'PlanRecord')"
+                                           type="checkbox"
+                                           id="chkBoard_@column.Progress"
+                                           @(column.Visible ? "checked" : "")>
+                                    <label class="form-check-label stretched-link" for="chkBoard_@column.Progress"> @translator.Translate(userLanguage, column.Name)</label>
+                                </div>
+                            </li>
+                        }
+
                     </ul>
                 </div>
             }
@@ -42,65 +60,72 @@
         </div>
     </div>
 </div>
+<div class="row">
+    <div class="d-md-none py-2 mt-2 mb-2 planner-nav">
+        <div class="d-flex justify-content-around">
+            @foreach (var column in boardColumns)
+            {
+                var items = Model.Where(x => x.Progress == column.Progress).OrderBy(x => x.Priority).ToList();
+                var columnStyle = column.Visible ? $"order: {column.Order};" : $"order: {column.Order}; display: none;";
+                <a href="#board-@column.Progress.ToString()"
+                   onclick="return scrollToColumn(this)"
+                   class="btn btn-outline-primary px-2 py-2 border-2"
+                   style="@columnStyle"
+                   data-column="@column.Progress.ToString()"
+                   ondragover="dragOver(event)"
+                   ondragleave="dragLeave(event)"
+                   ondrop="dropBox(event, '@column.Progress')">
+                    @translator.Translate(userLanguage, column.Name) <span class="fs-6 opacity-75">(@items.Count)</span>
+                </a>
+            }
+        </div>
+    </div>
+</div>
 <div class="row vehicleDetailTabContainer flex-grow-1">
-    <div class="col-12">
+    <div class="col-12 planner-flex">
+
         <div class="row mt-2 showOnPrint">
             <div class="d-flex">
                 <img src="@config.GetLogoUrl()" class="lubelogger-logo" />
             </div>
         </div>
-        <div class="row swimlane">
-            <div class="col-3 d-flex flex-column swimlane" ondragover="dragOver(event)" ondrop="dropBox(event, 'Backlog')">
-                <div class="row sticky-top frosted">
-                    <div class="col-12 d-flex justify-content-center" style="height:5vh;">
-                        <span class="display-7">@translator.Translate(userLanguage,"Planned")</span>
+        <div class="row mt-2 planner-board d-flex flex-nowrap overflow-auto">
+            @foreach (var column in boardColumns)
+            {
+                var items = Model.Where(x => x.Progress == column.Progress).OrderBy(x => x.Priority).ToList();
+                var columnIcon = StaticHelper.GetPlannerColumnIcon(column.Progress);
+                var columnStyle = column.Visible ? $"order: {column.Order};" : $"order: {column.Order}; display: none;";
+                <div id="board-@column.Progress.ToString()"
+                     class="pb-4 planner-column"
+                     style="@columnStyle"
+                     data-column="@column.Progress.ToString()"
+                     ondragover="dragOver(event)"
+                     ondragleave="dragLeave(event)"
+                     ondrop="dropBox(event, '@column.Progress')">
+                    <div class="row sticky-top frosted">
+                        <div class="col-12 d-flex align-items-center">
+                            <i class="bi @columnIcon"></i>
+                            <span class="lead m-2">@translator.Translate(userLanguage, column.Name)</span>
+                            <span class="badge text-body-secondary bg-secondary-subtle">@items.Count</span>
+                        </div>
                     </div>
+                    @foreach (var planRecord in items)
+                    {
+                        @await Html.PartialAsync("Plan/_PlanRecordItem", planRecord)
+                    }
                 </div>
-                @foreach (PlanRecord planRecord in backLogItems)
-                {
-                    @await Html.PartialAsync("Plan/_PlanRecordItem", planRecord)
-                }
-            </div>
-            <div class="col-3 d-flex flex-column swimlane" ondragover="dragOver(event)" ondrop="dropBox(event, 'InProgress')">
-                <div class="row sticky-top frosted">
-                    <div class="col-12 d-flex justify-content-center" style="height:5vh;">
-                        <span class="display-7">@translator.Translate(userLanguage,"Doing")</span>
-                    </div>
-                </div>
-                @foreach (PlanRecord planRecord in inProgressItems)
-                {
-                    @await Html.PartialAsync("Plan/_PlanRecordItem", planRecord)
-                }
-            </div>
-            <div class="col-3 d-flex flex-column swimlane" ondragover="dragOver(event)" ondrop="dropBox(event, 'Testing')">
-                <div class="row sticky-top frosted">
-                    <div class="col-12 d-flex justify-content-center" style="height:5vh;">
-                        <span class="display-7">@translator.Translate(userLanguage,"Testing")</span>
-                    </div>
-                </div>
-                @foreach (PlanRecord planRecord in testingItems)
-                {
-                    @await Html.PartialAsync("Plan/_PlanRecordItem", planRecord)
-                }
-            </div>
-            <div class="col-3 d-flex flex-column swimlane" ondragover="dragOver(event)" ondrop="dropBox(event, 'Done')">
-                <div class="row sticky-top frosted">
-                    <div class="col-12 d-flex justify-content-center" style="height:5vh;">
-                        <span class="display-7">@translator.Translate(userLanguage,"Done")</span>
-                    </div>
-                </div>
-                @foreach (PlanRecord planRecord in doneItems)
-                {
-                    @await Html.PartialAsync("Plan/_PlanRecordItem", planRecord)
-                }
-            </div>
+            }
+        </div>
+    </div>
+    <div class="row showOnPrint">
+        <div class="col-12 lubelogger-report-banner">
+            @StaticHelper.ReportNote
         </div>
     </div>
 </div>
 <div class="row lubelogger-record-nav pt-1 hideOnPrint">
     <div class="d-flex justify-content-between">
-            <button onclick="showPlanRecordTemplatesModal()" class="btn btn-outline-secondary btn-md mt-1 mb-1"><i class="bi bi-file-earmark-text"></i></button>
-            <button onclick="showAddPlanRecordModal()" class="btn btn-outline-primary btn-md mt-1 mb-1"><i class="bi bi-plus-lg"></i></button>
+        <button onclick="showAddPlanRecordModal()" class="btn btn-outline-primary btn-md mt-1 mb-1"><i class="bi bi-plus-lg"></i></button>
         <div>
             <button class="btn btn-outline-secondary btn-md mt-1 mb-1" onclick="showDropDownForRecordNav(this)" data-bs-toggle="dropdown" aria-expanded="false"><i class="bi bi-three-dots"></i></button>
             <ul class="dropdown-menu record-dropdown">
@@ -133,10 +158,19 @@
 
 <ul class="table-context-menu dropdown-menu" style="display:none;">
     <li><h6 class="dropdown-header context-menu-move move-header">@translator.Translate(userLanguage, "Move To")</h6></li>
-    <li><a class="dropdown-item context-menu-move move-planned" href="#"><div class="d-flex justify-content-between"><span class="me-5">@translator.Translate(userLanguage, "Planned")</span><i class="bi bi-list-task"></i></div></a></li>
-    <li><a class="dropdown-item context-menu-move move-doing" href="#"><div class="d-flex justify-content-between"><span class="me-5">@translator.Translate(userLanguage, "Doing")</span><i class="bi bi-tools"></i></div></a></li>
-    <li><a class="dropdown-item context-menu-move move-testing" href="#"><div class="d-flex justify-content-between"><span class="me-5">@translator.Translate(userLanguage, "Testing")</span><i class="bi bi-eyeglasses"></i></div></a></li>
-    <li><a class="dropdown-item context-menu-move move-done" href="#"><div class="d-flex justify-content-between"><span class="me-5">@translator.Translate(userLanguage, "Done")</span><i class="bi bi-check2-all"></i></div></a></li>
+    @foreach (var column in boardColumns)
+    {
+        var columnIcon = StaticHelper.GetPlannerColumnIcon(column.Progress);
+        var columnStyle = column.Visible ? $"" : $"display: none;";
+        <li>
+            <a class="dropdown-item context-menu-move" data-column="@column.Progress.ToString()" href="#"  style="@columnStyle">
+                <div class="d-flex justify-content-between">
+                    <span class="me-5">@translator.Translate(userLanguage, column.Name)</span>
+                    <i class="bi @columnIcon"></i>
+                </div>
+            </a>
+        </li>
+    }
     <li><hr class="context-menu-move move-header dropdown-divider"></li>
     <li><a class="dropdown-item context-menu-move move-header context-menu-duplicate" href="#"><div class="d-flex justify-content-between"><span class="me-5">@translator.Translate(userLanguage, "Duplicate")</span><i class="bi bi-copy"></i></div></a></li>
     <li><a class="dropdown-item context-menu-move move-header context-menu-duplicate-vehicle" href="#"><div class="d-flex justify-content-between"><span class="me-5">@translator.Translate(userLanguage, "Duplicate To Vehicle")</span><i class="bi bi-copy"></i></div></a></li>
@@ -146,9 +180,15 @@
     <li><a class="dropdown-item context-menu-move move-header text-danger context-menu-delete" href="#"><div class="d-flex justify-content-between"><span class="me-5">@translator.Translate(userLanguage, "Delete")</span><i class="bi bi-trash"></i></div></a></li>
 </ul>
 <script>
+    var _planBoardColumns = @Html.Raw(Json.Serialize(boardColumns));
     function getPlanUserConfig(){
         return {
-            autoFillOdometer: "@autoFillOdometer" == "True"
+            autoFillOdometer: "@autoFillOdometer" == "True",
+            boardColumns: _planBoardColumns
         }
     }
 </script>
+@if (userColumnPreferences.Any())
+{
+    @await Html.PartialAsync("_UserColumnPreferences", userColumnPreferences)
+}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -44,13 +44,76 @@ html {
     height: 65vh;
 }
 
-.swimlane {
+/* Plan board flex column container */
+.planner-flex {
+    flex: 1 1 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+/* The scrollable planner container */
+.planner-board {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    align-items: stretch;
+    scroll-behavior: smooth;
+    gap: 1rem;
+}
+.planner-column {
+    background: rgba(127, 127, 127, 0.1);
+    overflow-y: auto;
     height: 100%;
+    max-height: 100%;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+    border-radius: 0.5rem;
+    flex: 0 0 312px;
+}
+.planner-column.drag-hover {
+    background-color: rgba(var(--bs-primary-rgb), 0.15);
+    box-shadow: inset 0 0 0 3px var(--bs-primary);
+}
+.planner-nav a {
+    transition: all 0.2s ease;
+}
+.planner-nav .drag-hover {
+    background-color: var(--bs-primary) !important;
+    color: white !important;
+    transform: scale(1.2);
 }
 
-    .swimlane:not(:last-child) {
-        border-right-style: solid;
+@media (max-width: 768px) {
+    /* Single board visible on mobile */
+    .planner-board {
+        overflow-x: auto;
+        scroll-snap-type: x mandatory;
+        scroll-behavior: smooth;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
     }
+    .planner-board::-webkit-scrollbar {
+        display: none;
+    }
+    .planner-column {
+        scroll-snap-align: center;
+        flex: 0 0 100%;
+    }
+}
+
+@media (min-width: 768px) {
+    .planner-board:not(:has(.planner-column:not([style*="display: none"]):not([style*="display:none"]) ~ .planner-column:not([style*="display: none"]):not([style*="display:none"])))
+    .planner-column:not([style*="display: none"]):not([style*="display:none"]) { flex: 0 0 100%; }
+
+    .planner-board:has(.planner-column:not([style*="display: none"]):not([style*="display:none"]) ~ .planner-column:not([style*="display: none"]):not([style*="display:none"])):not(:has(.planner-column:not([style*="display: none"]):not([style*="display:none"]) ~ .planner-column:not([style*="display: none"]):not([style*="display:none"]) ~ .planner-column:not([style*="display: none"]):not([style*="display:none"])))
+    .planner-column:not([style*="display: none"]):not([style*="display:none"]) { flex: 0 0 calc(50% - 0.5rem); }
+
+}
+@media (min-width: 1200px) {
+    .planner-board:has(.planner-column:not([style*="display: none"]):not([style*="display:none"]) ~ .planner-column:not([style*="display: none"]):not([style*="display:none"]) ~ .planner-column:not([style*="display: none"]):not([style*="display:none"])):not(:has(.planner-column:not([style*="display: none"]):not([style*="display:none"]) ~ .planner-column:not([style*="display: none"]):not([style*="display:none"]) ~ .planner-column:not([style*="display: none"]):not([style*="display:none"]) ~ .planner-column:not([style*="display: none"]):not([style*="display:none"])))
+    .planner-column:not([style*="display: none"]):not([style*="display:none"]) { flex: 0 0 calc(33.333% - 0.667rem); }
+}
 
 .showOnPrint {
     display: none;
@@ -145,6 +208,61 @@ html {
     tr {
         border: hidden;
     }
+
+    .planner-nav {
+        display: none !important;
+    }
+    .planner-board {
+        flex: none !important;
+        padding-right: calc(var(--bs-gutter-x) * .5) !important;
+        padding-left: calc(var(--bs-gutter-x) * .5) !important;
+        display: block !important;
+        overflow: visible !important;
+        height: auto !important;
+    }
+    .planner-column {
+        display: block !important;
+        width: 100% !important;
+        flex: none !important;
+        overflow: visible !important;
+        height: auto !important;
+        max-height: none !important;
+        background: transparent !important;
+        margin-bottom: 1rem;
+        border: none !important;
+        padding: 0.5rem;
+    }
+    .task-card {
+        background-color: #fff !important;
+        border: 1px solid #000 !important;
+        box-shadow: none !important;
+        transform: none !important;
+        cursor: default !important;
+        page-break-inside: avoid;
+        margin-bottom: 0.5rem;
+        opacity: 1 !important;
+    }
+    .task-card:hover {
+        transform: none !important;
+        box-shadow: none !important;
+    }
+    .task-card .badge{
+        font-size: 14px !important;
+    }
+    .task-card .title-container {
+        max-height:fit-content !important;
+        overflow: auto !important;
+    }
+    .planner-column .sticky-top {
+        position: relative !important;
+        background-color: transparent !important;
+    }
+    .planner-column .sticky-top .badge {
+        color: #000 !important;
+        background-color: #fff !important;
+    }
+     
+
 }
 
 .chartContainer {
@@ -422,35 +540,27 @@ input[type="file"] {
     max-width: 75%;
 }
 
-.taskCard {
-    max-height: 20vh;
-    padding: 0.5rem;
-    overflow: hidden;
-    border-radius: 4px;
+.task-card {
+    background-color: var(--bs-body-bg);
+    padding:0.5rem;
+    overflow:hidden;
+    border-radius: 0.5em;
     box-shadow: 0 6px 10px rgba(0,0,0,.08), 0 0 6px rgba(0,0,0,.05);
     transition: .3s transform cubic-bezier(.155,1.105,.295,1.12),.3s box-shadow,.3s -webkit-transform cubic-bezier(.155,1.105,.295,1.12);
     cursor: pointer;
 }
-
-    .taskCard.nodrag {
-        cursor: not-allowed;
-    }
-
-.taskCard-title {
-    font-size: 1.5rem;
-    font-weight: 300;
-    max-height: 10vh;
+.task-card.nodrag{
+    cursor:not-allowed;
 }
-
-[data-bs-theme=dark] .taskCard {
-    background-color: rgba(255,255,255,0.5);
+.task-card-title{
+    word-wrap: break-word;
 }
-
-[data-bs-theme=light] .taskCard {
-    background-color: rgba(80,80,80,0.25);
+.task-card .title-container {
+    max-height: 9vh;
+    overflow: hidden;
+    line-height: 1.5;
 }
-
-.override-hide {
+.override-hide{
     display: none !important;
 }
 
@@ -502,12 +612,6 @@ input[type="file"] {
     padding: 0.438rem 0rem !important;
     background-color: inherit !important;
 }
-
-.planner-indicator {
-    font-size: 1em;
-    padding: 0.2em;
-}
-
 html[data-bs-theme="dark"] .btn-adaptive {
     --bs-btn-color: #fff;
     --bs-btn-bg: #212529;


### PR DESCRIPTION


## Planner Changes
I've made changes to make the planner easier and quicker to use. Clearer column and card separation and clear labels reduce the need to interpret icons or remember meanings. Both dark and light themes supported. Completed items are slightly faded so active tasks stand out without removing context.

## Preview

| Desktop Light Mode | Desktop Dark Mode |
|------------------|-----------------|
| <img width="400" src="https://github.com/user-attachments/assets/fae9b812-e331-4a53-8f5c-d785b7748eb6" /> | <img width="400" src="https://github.com/user-attachments/assets/3b801b4b-f9df-40ba-9970-474a26bb2525" /> |

### Mobile

| Mobile Light Mode | Mobile Dark Mode |
|-----------------|----------------|
| <img width="200" src="https://github.com/user-attachments/assets/ba7e6063-1640-4dce-87cc-3b79b7f9c605" /> | <img width="200" src="https://github.com/user-attachments/assets/936486a2-e31a-4ddb-b298-dce2dd5d686b" /> |



## Summary of Changes

### Controller / Models / Classes

**StaticHelper.cs**

* **GetPlanRecordColor()** - Updated priority colour mapping
* **GetPlanRecordTextColor()** - **NEW** - Returns text colour classes for priorities
* **GetPlannerColumnIcon()** - **NEW** - Returns Bootstrap icons for each planner column
* **GetBoardColumnsWithUserPreferences()** - **NEW** - Returns BoardColumn list with of columns with the user visibility and ordering preference.

**BoardColumn.cs**

* **NEW** - Adds `BoardColumn` model that combines `PlanProgress` and `userConfig` for column visibility and ordering settings.


### Views

**_PlanRecords.cshtml**

* **NEW** - Redesigned planner to respect dark/light mode, improved separation of columns and visual hierarchy.
* **NEW** - Target drop column highlights when `task-cards` are dragged providing visual feedback for the active drop zone. On Mobile, the `planner-nav` acts as the drop zone.
* **NEW** - Columns are now dynamic  `@foreach (var column in boardColumns)` 
* **NEW** - Each column has a header badge showing item count

**_PlanRecordItem.cshtml**

* Card layout reorganised:

  * Priority badge moved to top-right float.
  * Import type badges (Service/Upgrade/Repair) moved to bottom-left.

* Visual hierarchy improved - notes moved to bottom, cost shown as badge.

**_PlanRecordModal.cshtml & _PlanRecordTemplateEditModal.cshtml**

* Label changed: **"Current Stage" > "Current Board"**.
* Dropdown respects  user's visible boards .
* Respects user column preferences and order.

### JavaScript 

**planrecord.js**

* **dragOver(), dragLeave(),** and **dropBox()** Modified to add/remove `drag-hover` class.

* **scrollToColumn()** - **NEW** - Click-based mobile navigation, Sets active state and scrolls to target column by data-column attribute.

* **configurePlanTableContextMenu()** - Updated to account for context menu items visiblity based on user config.

* Renamed variables:  * `swimlane` > `planner`

* Function signature updates  `currentSwimLane` > `currentColumn` in `showPlanTableContextMenu()`,  `showPlanTableContextMenuForMobile()` &  `detectPlanItemLongTouch()`

### Stylesheet

**site.css**

* **Responsive column width** - **NEW** - CSS-only implementation using :has() pseudo-selectors to count visible columns and adjust flex-basis automatically

    * `@media (max-width: 768px)` - 1+ column > 100% width.
    * `@media (min-width: 768px)` - 1 column > 100% width, 2 columns > 50% width, 3+ columns 312px width.
    * `@media (min-width: 1200px)` - 3 columns > 33.3% width. 4 visible columns > 25% / 312px.

* Renamed `swimlane` > `planner-board` & `planner-column`. And`taskCard` > `task-card`

* **Print** - Implemented single column print layout.
    

### Discussion Points

* Column sizing is using a combination of percentage widths and fixed width depending on bootstrap breakpoints as well as the number of columns visible. The css is not ideal as it's using :has() selectors based on display visibility. An alternative approach is to use javascript to add/remove classes to define how many columns are visible. I would also need to add a resize window event listener.
* Context menu column order is static as would require changing shared.js code.
* Sorting of taskcards is currently by priority. I'd prefer it if the done column was sorted by date completed (modified?) so most recently completed was at the top.