### PR TITLE
vehicleID for ReminderAPIExportModel

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(dotnet build:*)"
-    ]
-  }
-}


### PR DESCRIPTION
When calling the endpoint `/api/vehicle/info/?vehicleId=1`, fixed an issue where `nextReminder.vehicleId` being empty caused a 500 error.  

The error occurred during serialization when the `culture-invariant` header was supplied due to an invalid type cast from an empty string to integer as vehicleId wasn't supplied to `ReminderAPIExportModel`.