### PR TITLE
Fix Reset IsElectric and IsDiesel for Add/Update Vehicle API endpoint

### DIFF
--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -298,6 +298,8 @@ namespace CarCareTracker.Controllers
                     ExtraFields = input.ExtraFields,
                     Tags = string.IsNullOrWhiteSpace(input.Tags) ? new List<string>() : input.Tags.Split(' ').Distinct().ToList()
                 };
+                vehicle.IsElectric = false;
+                vehicle.IsDiesel = false;
                 switch (input.FuelType)
                 {
                     case "Diesel":
@@ -380,6 +382,8 @@ namespace CarCareTracker.Controllers
                     existingVehicle.OdometerOptional = string.IsNullOrWhiteSpace(input.OdometerOptional) ? false : bool.Parse(input.OdometerOptional);
                     existingVehicle.ExtraFields = input.ExtraFields;
                     existingVehicle.Tags = string.IsNullOrWhiteSpace(input.Tags) ? new List<string>() : input.Tags.Split(' ').Distinct().ToList();
+                    existingVehicle.IsElectric = false;
+                    existingVehicle.IsDiesel = false;
                     switch (input.FuelType)
                     {
                         case "Diesel":


### PR DESCRIPTION
When updating `fuelType` via the API, `IsElectric` and `IsDiesel` could both remain `true` because previous values were not reset.

Explicitly reset `IsElectric` and `IsDiesel` before the `fuelType` switch statement to ensure correct state.

Applied to both `AddVehicle` and `UpdateVehicle` API endpoints.