### PR TITLE
Add feature to input SoC for EVs and calculate the efficiency based on that instead of only 100%-100%

### DIFF
--- a/Controllers/API/GasController.cs
+++ b/Controllers/API/GasController.cs
@@ -51,6 +51,7 @@ namespace CarCareTracker.Controllers
                     Cost = x.Cost.ToString(),
                     FuelConsumed = x.Gallons.ToString(),
                     FuelEconomy = x.MilesPerGallon.ToString(),
+                    SoC = x.SoC.ToString(),
                     IsFillToFull = x.IsFillToFull.ToString(),
                     MissedFuelUp = x.MissedFuelUp.ToString(),
                     Notes = x.Notes,
@@ -107,6 +108,7 @@ namespace CarCareTracker.Controllers
                     Cost = x.Cost.ToString(),
                     FuelConsumed = x.Gallons.ToString(),
                     FuelEconomy = x.MilesPerGallon.ToString(),
+                    SoC = x.SoC.ToString(),
                     IsFillToFull = x.IsFillToFull.ToString(),
                     MissedFuelUp = x.MissedFuelUp.ToString(),
                     Notes = x.Notes,
@@ -168,7 +170,7 @@ namespace CarCareTracker.Controllers
                     Date = DateTime.Parse(input.Date),
                     Mileage = int.Parse(input.Odometer),
                     Gallons = decimal.Parse(input.FuelConsumed),
-                    IsFillToFull = bool.Parse(input.IsFillToFull),
+                    SoC = !string.IsNullOrWhiteSpace(input.SoC) ? int.Parse(input.SoC) : (bool.Parse(input.IsFillToFull) ? 100 : 0),
                     MissedFuelUp = bool.Parse(input.MissedFuelUp),
                     Notes = string.IsNullOrWhiteSpace(input.Notes) ? "" : input.Notes,
                     Cost = decimal.Parse(input.Cost),
@@ -266,7 +268,7 @@ namespace CarCareTracker.Controllers
                     existingRecord.Date = DateTime.Parse(input.Date);
                     existingRecord.Mileage = int.Parse(input.Odometer);
                     existingRecord.Gallons = decimal.Parse(input.FuelConsumed);
-                    existingRecord.IsFillToFull = bool.Parse(input.IsFillToFull);
+                    existingRecord.SoC = !string.IsNullOrWhiteSpace(input.SoC) ? int.Parse(input.SoC) : (bool.Parse(input.IsFillToFull) ? 100 : 0);
                     existingRecord.MissedFuelUp = bool.Parse(input.MissedFuelUp);
                     existingRecord.Notes = string.IsNullOrWhiteSpace(input.Notes) ? "" : input.Notes;
                     existingRecord.Cost = decimal.Parse(input.Cost);

--- a/Controllers/Vehicle/GasController.cs
+++ b/Controllers/Vehicle/GasController.cs
@@ -99,7 +99,7 @@ namespace CarCareTracker.Controllers
                 Date = result.Date.ToShortDateString(),
                 Files = result.Files,
                 Gallons = result.Gallons,
-                IsFillToFull = result.IsFillToFull,
+                SoC = result.SoC,
                 MissedFuelUp = result.MissedFuelUp,
                 Notes = result.Notes,
                 Tags = result.Tags,

--- a/Controllers/Vehicle/ImportController.cs
+++ b/Controllers/Vehicle/ImportController.cs
@@ -731,16 +731,21 @@ namespace CarCareTracker.Controllers
                                     {
                                         convertedRecord.Cost = decimal.Parse(importModel.Cost, NumberStyles.Any);
                                     }
-                                    if (string.IsNullOrWhiteSpace(importModel.IsFillToFull) && !string.IsNullOrWhiteSpace(importModel.PartialFuelUp))
+                                    if (!string.IsNullOrWhiteSpace(importModel.SoC) && int.TryParse(importModel.SoC.Trim(), out int parsedSoC))
+                                    {
+                                        // New SoC field takes priority
+                                        convertedRecord.SoC = Math.Clamp(parsedSoC, 0, 100);
+                                    }
+                                    else if (string.IsNullOrWhiteSpace(importModel.IsFillToFull) && !string.IsNullOrWhiteSpace(importModel.PartialFuelUp))
                                     {
                                         var parsedBool = importModel.PartialFuelUp.Trim() == "1";
-                                        convertedRecord.IsFillToFull = !parsedBool;
+                                        convertedRecord.SoC = !parsedBool ? 100 : 0;
                                     }
                                     else if (!string.IsNullOrWhiteSpace(importModel.IsFillToFull))
                                     {
                                         var possibleFillToFullValues = new List<string> { "1", "true", "full" };
                                         var parsedBool = possibleFillToFullValues.Contains(importModel.IsFillToFull.Trim().ToLower());
-                                        convertedRecord.IsFillToFull = parsedBool;
+                                        convertedRecord.SoC = parsedBool ? 100 : 0;
                                     }
                                     if (!string.IsNullOrWhiteSpace(importModel.MissedFuelUp))
                                     {

--- a/Helper/StaticHelper.cs
+++ b/Helper/StaticHelper.cs
@@ -876,6 +876,7 @@ namespace CarCareTracker.Helper
             _csv.WriteField(nameof(GasRecordExportModel.FuelConsumed));
             _csv.WriteField(nameof(GasRecordExportModel.Cost));
             _csv.WriteField(nameof(GasRecordExportModel.FuelEconomy));
+            _csv.WriteField(nameof(GasRecordExportModel.SoC));
             _csv.WriteField(nameof(GasRecordExportModel.IsFillToFull));
             _csv.WriteField(nameof(GasRecordExportModel.MissedFuelUp));
             _csv.WriteField(nameof(GasRecordExportModel.Notes));
@@ -892,6 +893,7 @@ namespace CarCareTracker.Helper
                 _csv.WriteField(genericRecord.FuelConsumed);
                 _csv.WriteField(genericRecord.Cost);
                 _csv.WriteField(genericRecord.FuelEconomy);
+                _csv.WriteField(genericRecord.SoC);
                 _csv.WriteField(genericRecord.IsFillToFull);
                 _csv.WriteField(genericRecord.MissedFuelUp);
                 _csv.WriteField(genericRecord.Notes);

--- a/MapProfile/ImportMappers.cs
+++ b/MapProfile/ImportMappers.cs
@@ -21,6 +21,7 @@ namespace CarCareTracker.MapProfile
             Map(m => m.Price).Name(["price"]);
             Map(m => m.PartialFuelUp).Name(["partial_fuelup", "partial tank", "partial_fill"]);
             Map(m => m.IsFillToFull).Name(["isfilltofull", "filled up"]);
+            Map(m => m.SoC).Name(["soc", "state_of_charge", "charge_level", "chargelevel"]);
             Map(m => m.Description).Name(["description"]);
             Map(m => m.MissedFuelUp).Name(["missed_fuelup", "missedfuelup", "missed fill up", "missed_fill"]);
             Map(m => m.PartSupplier).Name(["partsupplier"]);

--- a/Models/GasRecord/GasRecord.cs
+++ b/Models/GasRecord/GasRecord.cs
@@ -1,4 +1,4 @@
-﻿namespace CarCareTracker.Models
+namespace CarCareTracker.Models
 {
     public class GasRecord
     {
@@ -14,7 +14,49 @@
         /// </summary>
         public decimal Gallons { get; set; }
         public decimal Cost { get; set; }
-        public bool IsFillToFull { get; set; } = true;
+        /// <summary>
+        /// State of Charge at fill-up (1-100). 0 = not tracked (skip efficiency calculation).
+        /// Legacy "IsFillToFull=true" records (which lack a SoC field) are migrated on read:
+        ///   IsFillToFull=true  -> SoC=100 (full charge)
+        ///   IsFillToFull=false -> SoC=0   (not tracked)
+        /// EV drivers charging to e.g. 80% consistently should set SoC=80 on every charge.
+        /// Efficiency is then calculated between consecutive entries with the same SoC value.
+        /// </summary>
+        private int _soC = -1; // -1 = not yet migrated; will be computed from IsFillToFull on first access.
+        public int SoC
+        {
+            get
+            {
+                if (_soC == -1)
+                {
+                    // Migrate from legacy IsFillToFull field
+                    _soC = _isFillToFull ? 100 : 0;
+                }
+                return _soC;
+            }
+            set => _soC = value;
+        }
+
+        /// <summary>
+        /// Legacy field kept for JSON backward compatibility. New code should use SoC.
+        /// When SoC is explicitly set (>= 0), IsFillToFull reflects SoC == 100.
+        /// When reading old JSON that has IsFillToFull but no SoC, this seeds the SoC migration.
+        /// </summary>
+        private bool _isFillToFull = true;
+        public bool IsFillToFull
+        {
+            get => SoC == 100;
+            set
+            {
+                _isFillToFull = value;
+                // Only apply migration if SoC hasn't been explicitly set yet.
+                if (_soC == -1)
+                {
+                    _soC = value ? 100 : 0;
+                }
+            }
+        }
+
         public bool MissedFuelUp { get; set; } = false;
         public string Notes { get; set; } = string.Empty;
         public List<UploadedFiles> Files { get; set; } = new List<UploadedFiles>();

--- a/Models/GasRecord/GasRecordInput.cs
+++ b/Models/GasRecord/GasRecordInput.cs
@@ -1,4 +1,4 @@
-﻿namespace CarCareTracker.Models
+namespace CarCareTracker.Models
 {
     public class GasRecordInput
     {
@@ -14,7 +14,32 @@
         /// </summary>
         public decimal Gallons { get; set; }
         public decimal Cost { get; set; }
-        public bool IsFillToFull { get; set; } = true;
+        /// <summary>
+        /// State of Charge at fill-up (0-100). 0 = not tracked. See GasRecord.SoC for details.
+        /// </summary>
+        private int _soC = 100;
+        private bool _soCExplicitlySet = false;
+        public int SoC
+        {
+            get => _soC;
+            set { _soC = value; _soCExplicitlySet = true; }
+        }
+        /// <summary>
+        /// Legacy field for backward compatibility with form submissions that still send isFillToFull.
+        /// If SoC was explicitly set (e.g. EV form sending soC=80), IsFillToFull is ignored.
+        /// </summary>
+        public bool IsFillToFull
+        {
+            get => SoC == 100;
+            set
+            {
+                // Only apply if SoC was NOT explicitly set — avoids overwriting soC=80 with isFillToFull=false.
+                if (!_soCExplicitlySet)
+                {
+                    _soC = value ? 100 : 0;
+                }
+            }
+        }
         public bool MissedFuelUp { get; set; } = false;
         public string Notes { get; set; } = string.Empty;
         public List<UploadedFiles> Files { get; set; } = new List<UploadedFiles>();
@@ -32,7 +57,7 @@
             Mileage = Mileage, 
             VehicleId = VehicleId, 
             Files = Files,
-            IsFillToFull = IsFillToFull,
+            SoC = SoC,
             MissedFuelUp = MissedFuelUp,
             Notes = Notes,
             Tags = Tags,

--- a/Models/GasRecord/GasRecordViewModel.cs
+++ b/Models/GasRecord/GasRecordViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace CarCareTracker.Models
+namespace CarCareTracker.Models
 {
     public class GasRecordViewModel
     {
@@ -18,12 +18,21 @@
         public int DeltaMileage { get; set; }
         public decimal MilesPerGallon { get; set; }
         public decimal CostPerGallon { get; set; }
-        public bool IsFillToFull { get; set; }
+        /// <summary>
+        /// State of Charge at fill-up (0-100). 0 = not tracked. 100 = full. Other = partial (e.g. 80 for EV).
+        /// </summary>
+        public int SoC { get; set; } = 100;
+        public bool IsFillToFull => SoC == 100;
         public bool MissedFuelUp { get; set; }
         public string Notes { get; set; } = string.Empty;
         public List<string> Tags { get; set; } = new List<string>();
         public List<ExtraField> ExtraFields { get; set; } = new List<ExtraField>();
         public List<UploadedFiles> Files { get; set; } = new List<UploadedFiles>();
-        public bool IncludeInAverage { get { return MilesPerGallon > 0 || (!IsFillToFull && !MissedFuelUp) || (Mileage == default && !MissedFuelUp); } }
+        /// <summary>
+        /// True if this record should be included in average efficiency calculation.
+        /// SoC=0 (not tracked) records are excluded from the average (but their consumption
+        /// is accumulated into the next SoC-tracked calculation in GasHelper).
+        /// </summary>
+        public bool IncludeInAverage { get { return MilesPerGallon > 0 || (SoC == 0 && !MissedFuelUp) || (Mileage == default && !MissedFuelUp); } }
     }
 }

--- a/Models/Shared/ImportModel.cs
+++ b/Models/Shared/ImportModel.cs
@@ -25,6 +25,7 @@ namespace CarCareTracker.Models
         public string Price { get; set; } = string.Empty;
         public string PartialFuelUp { get; set; } = string.Empty;
         public string IsFillToFull { get; set; } = string.Empty;
+        public string SoC { get; set; } = string.Empty;
         public string MissedFuelUp { get; set; } = string.Empty;
         public string PartNumber { get; set; } = string.Empty;
         public string PartSupplier { get; set; } = string.Empty;
@@ -122,6 +123,8 @@ namespace CarCareTracker.Models
         public string Cost { get; set; } = string.Empty;
         [JsonConverter(typeof(FromDecimalOptional))]
         public string FuelEconomy { get; set; } = string.Empty;
+        [JsonConverter(typeof(FromIntOptional))]
+        public string SoC { get; set; } = string.Empty;
         [JsonConverter(typeof(FromBoolOptional))]
         public string IsFillToFull { get; set; } = string.Empty;
         [JsonConverter(typeof(FromBoolOptional))]

--- a/Views/Vehicle/Gas/_Gas.cshtml
+++ b/Views/Vehicle/Gas/_Gas.cshtml
@@ -209,7 +209,13 @@
                         <td class="col-2 flex-grow-1 flex-shrink-1 text-truncate" data-column="odometer" data-gas-type="mileage" data-gas-aggregate="@gasRecord.DeltaMileage" data-gas-original="@gasRecord.Mileage">@(gasRecord.Mileage == default ? "---" : gasRecord.Mileage.ToString())</td>
                         <td class="col-1 flex-grow-1 flex-shrink-1 text-truncate" data-column="delta" data-gas-type="totaldistance">@(gasRecord.DeltaMileage == default ? "---" : gasRecord.DeltaMileage)</td>
                         <td class="col-2 flex-grow-1 flex-shrink-1 text-truncate" data-column="consumption" data-gas-type="consumption" data-gas-aggregate="@gasRecord.Gallons">@gasRecord.Gallons.ToString(gasConsumptionFormat)</td>
-                        <td class="col-3 flex-grow-1 flex-shrink-1 text-truncate" data-column="fueleconomy" data-gas-type="fueleconomy" data-aggregated='@(gasRecord.IncludeInAverage.ToString().ToLower())'>@(gasRecord.MilesPerGallon == 0 ? "---" : gasRecord.MilesPerGallon.ToString("F"))</td>
+                        <td class="col-3 flex-grow-1 flex-shrink-1 text-truncate" data-column="fueleconomy" data-gas-type="fueleconomy" data-aggregated='@(gasRecord.IncludeInAverage.ToString().ToLower())'>
+                            @(gasRecord.MilesPerGallon == 0 ? "---" : gasRecord.MilesPerGallon.ToString("F"))
+                            @if (gasRecord.SoC > 0)
+                            {
+                                <span class="badge bg-info ms-1" title="@translator.Translate(userLanguage, "Charge Level")">@gasRecord.SoC%</span>
+                            }
+                        </td>
                         <td class="col-1 flex-grow-1 flex-shrink-1 text-truncate" data-column="cost" data-record-type="cost">@((hideZero && gasRecord.Cost == default) ? "---" : gasRecord.Cost.ToString(gasCostFormat))</td>
                         <td class="col-1 flex-grow-1 flex-shrink-1 text-truncate" data-column="unitcost" data-gas-type="unitcost">@((hideZero && gasRecord.CostPerGallon == default) ? "---" : gasRecord.CostPerGallon.ToString(gasCostFormat))</td>
                         <td class="col-1 flex-grow-1 flex-shrink-1 text-truncate" style='display:none;' data-column="attachments">@await Html.PartialAsync("_AttachmentColumn", gasRecord.Files)</td>

--- a/Views/Vehicle/Gas/_GasModal.cshtml
+++ b/Views/Vehicle/Gas/_GasModal.cshtml
@@ -67,13 +67,29 @@
                     <label for="gasRecordGallons">@($"{translator.Translate(userLanguage, "Fuel Consumption")}({consumptionUnit})")</label>
                     <input type="text" inputmode="decimal" onkeydown="interceptDecimalKeys(event)" onkeyup="@(useThreeDecimalsConsumption ? "fixDecimalInput(this, 3)" : "fixDecimalInput(this, 2)")" id="gasRecordGallons" class="form-control" placeholder="@translator.Translate(userLanguage,"Amount of gas refueled")" value="@(isNew ? "" : Model.GasRecord.Gallons)">
                     <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" role="switch" id="gasIsFillToFull" checked="@Model.GasRecord.IsFillToFull">
-                        <label class="form-check-label" for="gasIsFillToFull">@translator.Translate(userLanguage,"Is Filled To Full")</label>
-                    </div>
-                    <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" role="switch" id="gasIsMissed" checked="@Model.GasRecord.MissedFuelUp">
                         <label class="form-check-label" for="gasIsMissed">@translator.Translate(userLanguage,"Missed Fuel Up(Skip MPG Calculation)")</label>
                     </div>
+                    @if (useKwh)
+                    {
+                        <div class="mb-2">
+                            <label for="gasRecordSoC">@translator.Translate(userLanguage, "Charge Level at Fill-Up") (%)</label>
+                            <div class="input-group">
+                                <input type="number" id="gasRecordSoC" class="form-control" min="0" max="100" step="1"
+                                       value="@(isNew ? 100 : Model.GasRecord.SoC)"
+                                       placeholder="100">
+                                <span class="input-group-text">%</span>
+                            </div>
+                            <div class="form-text">@translator.Translate(userLanguage, "Set to your usual charge limit (e.g. 80). Efficiency is calculated between consecutive entries at the same charge level. Use 100 for a full charge, 0 to skip calculation.")</div>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" role="switch" id="gasIsFillToFull" checked="@Model.GasRecord.IsFillToFull">
+                            <label class="form-check-label" for="gasIsFillToFull">@translator.Translate(userLanguage,"Is Filled To Full")</label>
+                        </div>
+                    }
                     <label for="GasRecordCost">@translator.Translate(userLanguage,"Cost")</label>
                     @if (isNew)
                     {

--- a/wwwroot/js/gasrecord.js
+++ b/wwwroot/js/gasrecord.js
@@ -87,7 +87,15 @@ function getAndValidateGasRecordValues() {
     var gasGallons = $("#gasRecordGallons").val();
     var gasCost = $("#gasRecordCost").val();
     var gasCostType = $("#gasCostType").val();
+    // SoC field (EV): 0-100. If present, use it directly.
+    // IsFillToFull checkbox (non-EV): fall back to this when SoC field is absent.
+    var gasSoCRaw = $("#gasRecordSoC").val();
     var gasIsFillToFull = $("#gasIsFillToFull").is(":checked");
+    var gasSoC = (gasSoCRaw !== undefined && gasSoCRaw !== "")
+        ? Math.min(100, Math.max(0, parseInt(gasSoCRaw) || 0))
+        : (gasIsFillToFull ? 100 : 0);
+    // Only send isFillToFull when the checkbox exists (non-EV); for EV we rely solely on soC.
+    var gasHasFillToFullCheckbox = $("#gasIsFillToFull").length > 0;
     var gasIsMissed = $("#gasIsMissed").is(":checked");
     var gasNotes = $("#gasRecordNotes").val();
     var gasTags = $("#gasRecordTag").val();
@@ -150,7 +158,8 @@ function getAndValidateGasRecordValues() {
         files: uploadedFiles,
         supplies: selectedSupplies,
         tags: gasTags,
-        isFillToFull: gasIsFillToFull,
+        soC: gasSoC,
+        isFillToFull: gasHasFillToFullCheckbox ? gasIsFillToFull : (gasSoC === 100),
         missedFuelUp: gasIsMissed,
         notes: gasNotes,
         extraFields: extraFields.extraFields,


### PR DESCRIPTION
As already discussed in #1263

**This PR made heavy use of AI (Claude).** However all changes have been tested in a Docker instance and I have made some minor changes myself as well. During testing I did not find any problems with the latest commit. This change does not break database backwards-compatibility and a downgrade is possible without problems. Non-EV cars are not affected by this change.

This PR changes the checkbox for EVs from "Filled to full" to an input to enter the SoC. If there has been the same SoC since the last efficiency calculation, the distance and energy consumption since then is used for the calculation. Existing "full" fuel up entries are considered 100%, all others are set to 0 and ignored. In the fuel overview, a little badge is shown indicating the SoC for that entry