### PR TITLE
Extend vehicle API endpoints to support all editable fields #1280

### DIFF
--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -294,11 +294,6 @@ namespace CarCareTracker.Controllers
                 Response.StatusCode = 400;
                 return Json(OperationResponse.Failed("Input object invalid, SoldDate could not be parsed as a date."));
             }
-            if (!string.IsNullOrWhiteSpace(input.HasOdometerAdjustment) && !bool.TryParse(input.HasOdometerAdjustment, out _))
-            {
-                Response.StatusCode = 400;
-                return Json(OperationResponse.Failed("Input object invalid, HasOdometerAdjustment could not be parsed as a boolean."));
-            }
             if (!string.IsNullOrWhiteSpace(input.OdometerMultiplier) && !decimal.TryParse(input.OdometerMultiplier, out _))
             {
                 Response.StatusCode = 400;
@@ -344,9 +339,9 @@ namespace CarCareTracker.Controllers
                     vehicle.PurchasePrice = input.PurchasePrice.Value;
                 if (input.SoldPrice != null)
                     vehicle.SoldPrice = input.SoldPrice.Value;
-                vehicle.HasOdometerAdjustment = !string.IsNullOrWhiteSpace(input.HasOdometerAdjustment) && bool.Parse(input.HasOdometerAdjustment);
                 vehicle.OdometerMultiplier = !string.IsNullOrWhiteSpace(input.OdometerMultiplier) ? input.OdometerMultiplier : "1";
                 vehicle.OdometerDifference = !string.IsNullOrWhiteSpace(input.OdometerDifference) ? input.OdometerDifference : "0";
+                vehicle.HasOdometerAdjustment = (vehicle.OdometerMultiplier != "1") || (vehicle.OdometerDifference != "0");
                 _dataAccess.SaveVehicle(vehicle);
                 if (vehicle.Id != default)
                 {
@@ -411,11 +406,6 @@ namespace CarCareTracker.Controllers
                 Response.StatusCode = 400;
                 return Json(OperationResponse.Failed("Input object invalid, SoldDate could not be parsed as a date."));
             }
-            if (!string.IsNullOrWhiteSpace(input.HasOdometerAdjustment) && !bool.TryParse(input.HasOdometerAdjustment, out _))
-            {
-                Response.StatusCode = 400;
-                return Json(OperationResponse.Failed("Input object invalid, HasOdometerAdjustment could not be parsed as a boolean."));
-            }
             if (!string.IsNullOrWhiteSpace(input.OdometerMultiplier) && !decimal.TryParse(input.OdometerMultiplier, out _))
             {
                 Response.StatusCode = 400;
@@ -466,12 +456,12 @@ namespace CarCareTracker.Controllers
                         existingVehicle.PurchasePrice = input.PurchasePrice.Value;
                     if (input.SoldPrice != null)
                         existingVehicle.SoldPrice = input.SoldPrice.Value;
-                    if (!string.IsNullOrWhiteSpace(input.HasOdometerAdjustment))
-                        existingVehicle.HasOdometerAdjustment = bool.Parse(input.HasOdometerAdjustment);
                     if (!string.IsNullOrWhiteSpace(input.OdometerMultiplier))
                         existingVehicle.OdometerMultiplier = input.OdometerMultiplier;
                     if (!string.IsNullOrWhiteSpace(input.OdometerDifference))
                         existingVehicle.OdometerDifference = input.OdometerDifference;
+                    if (!string.IsNullOrWhiteSpace(input.OdometerMultiplier) || !string.IsNullOrWhiteSpace(input.OdometerDifference))
+                        existingVehicle.HasOdometerAdjustment = (existingVehicle.OdometerMultiplier != "1") || (existingVehicle.OdometerDifference != "0");
                     _dataAccess.SaveVehicle(existingVehicle);
                     _eventLogic.PublishEvent(GetUserID(), WebHookPayload.Generic($"Updated Vehicle {existingVehicle.Year} {existingVehicle.Make} {existingVehicle.Model}({StaticHelper.GetVehicleIdentifier(existingVehicle)}) via API", "vehicle.update.api", User.Identity?.Name ?? string.Empty, existingVehicle.Id.ToString()));
                     return Json(OperationResponse.Succeed("Vehicle Updated"));

--- a/Models/Shared/ImportModel.cs
+++ b/Models/Shared/ImportModel.cs
@@ -290,8 +290,6 @@ namespace CarCareTracker.Models
         public string? SoldDate { get; set; }
         public decimal? PurchasePrice { get; set; }
         public decimal? SoldPrice { get; set; }
-        [JsonConverter(typeof(FromBoolOptional))]
-        public string? HasOdometerAdjustment { get; set; }
         [JsonConverter(typeof(FromDecimalOptional))]
         public string? OdometerMultiplier { get; set; }
         [JsonConverter(typeof(FromIntOptional))]

--- a/wwwroot/defaults/api.json
+++ b/wwwroot/defaults/api.json
@@ -62,6 +62,13 @@
                "licensePlate":"HITNCURBS",
                "fuelType":"Gasoline",
                "tags":"sedan nissan",
+               "imageLocation":"/images/image.jpg",
+               "purchaseDate":"2019-01-01",
+               "soldDate":"",
+               "purchasePrice":20000.00,
+               "soldPrice":0.00,
+               "odometerMultiplier":"1",
+               "odometerDifference":"0",
                "extraFields":[
                   {
                      "name":"VIN",
@@ -88,6 +95,13 @@
                "licensePlate":"HITNCURBS",
                "fuelType":"Diesel",
                "tags":"sedan nissan",
+               "imageLocation":"/images/image.jpg",
+               "purchaseDate":"2019-01-01",
+               "soldDate":"2023-06-15",
+               "purchasePrice":20000.00,
+               "soldPrice":15000.00,
+               "odometerMultiplier":"1",
+               "odometerDifference":"0",
                "extraFields":[
                   {
                      "name":"VIN",
@@ -1702,12 +1716,23 @@
             ]
          },
          {
+            "path":"/api/images/upload",
+            "description":"Upload an image (max 500KB). Returns a Location and Name - pass the Location value into the imageLocation field when calling the Add/Update Vehicle endpoints.",
+            "bodyParamName":"image",
+            "methodType":1,
+            "queryParams":[
+
+            ],
+            "hasBody":true,
+            "bodyIsFileUpload":true
+         },
+         {
             "path":"/api/documents/upload",
             "description":"Upload Documents",
             "bodyParamName":"documents",
             "methodType":1,
             "queryParams":[
-               
+
             ],
             "hasBody":true,
             "bodyIsFileUpload":true


### PR DESCRIPTION
This PR extend the existing `Vehicles` endpoint to include all editable fields bringing the API’s functionality in line with the UI as discussed in issue #1280 

The primary goal was to support adding and editing Purchase and Sold information via the API. While I was there it wasn't much effort to add the other missing fields too.

**Add/Update Vehicle (`POST /api/vehicle/add`, `PUT /api/vehicle/update`)**
- Added support for `ImageLocation`, `PurchaseDate`, `SoldDate`, `PurchasePrice`, `SoldPrice`, `OdometerMultiplier`, and `OdometerDifference` fields on the `VehicleInputModel`
- Added pre-flight validation for date-parseable strings (`PurchaseDate`, `SoldDate`), decimal (`OdometerMultiplier`), and integer (`OdometerDifference`) fields before attempting to apply them
- Add endpoint applies safe defaults (`OdometerMultiplier` = `"1"`, `OdometerDifference` = `"0"`, `HasOdometerAdjustment` = `false`) when fields are omitted. Update endpoint skips fields not provided for backwards compatibility. 
- I've also included the `IsElectric` and `IsDiesel` patch that resolves bug changing fuel type. 

**Image Upload (`POST /api/images/upload`)**
- New endpoint for uploading vehicle images via the API
- Validates `Content-Type` starts with `image/`
- Rejects files larger than `500KB` with a descriptive error (as no way to get width/height without including a 3rd party image package.
- Returns `Location` and `Name` on success, matching the existing `UploadedFiles` response pattern as used by documents upload endpoint


### Image Upload Flow

To set a vehicle image via the API, first upload the image, then pass the returned `location` into the vehicle add/update payload.

**1. Upload the image**

`POST /api/images/upload`

Multipart form upload with the file in the `image` field. Max 500KB.

Returns:
```
{
  "location": "/images/abc123.jpg",
  "name": "mycar.jpg"
}
```

**2. Use the `location` in Add or Update Vehicle**

`POST /api/vehicles/add`
```
{
  "year": 2019,
  "make": "Nissan",
  "model": "Altima",
  "identifier": "LicensePlate",
  "licensePlate": "HITNCURBS",
  "fuelType": "Gasoline",
  "imageLocation": "/images/abc123.jpg",
  "purchaseDate": "2019-01-01",
  "purchasePrice": 20000.00,
  "odometerMultiplier": "1.0",
  "odometerDifference": "0"
}
```

`PUT /api/vehicles/update`
```
{
  "id": 1,
  "year": 2019,
  "make": "Nissan",
  "model": "Altima",
  "identifier": "LicensePlate",
  "licensePlate": "HITNCURBS",
  "fuelType": "Gasoline",
  "imageLocation": "/images/abc123.jpg",
  "soldDate": "2023-06-15",
  "soldPrice": 15000.00
}
```

**Notes**
- `purchaseDate` / `soldDate` — ISO 8601 date strings, optional
- `purchasePrice` / `soldPrice` — decimal, optional
- `odometerMultiplier` / `odometerDifference` — if either is provided, odometer adjustment is automatically enabled on the vehicle
- All fields except the required vehicle identifiers are optional on update (patch behaviour)


