### PR TITLE
disable login-related views when OIDC-only login is enforced.

### DIFF
--- a/CarCareTracker.csproj
+++ b/CarCareTracker.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="LiteDB" Version="5.0.17" />
     <PackageReference Include="MailKit" Version="4.15.1" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
     <PackageReference Include="Npgsql" Version="9.0.4" />
   </ItemGroup>
 

--- a/Controllers/LoginController.cs
+++ b/Controllers/LoginController.cs
@@ -77,6 +77,11 @@ namespace CarCareTracker.Controllers
             {
                 return RedirectToAction("Index");
             }
+            var remoteAuthConfig = _config.GetOpenIDConfig();
+            if (remoteAuthConfig.DisableRegularLogin && !string.IsNullOrWhiteSpace(remoteAuthConfig.LogOutURL))
+            {
+                return RedirectToAction("Index");
+            }
             var viewModel = new LoginModel
             {
                 EmailAddress = string.IsNullOrWhiteSpace(email) ? string.Empty : email,
@@ -86,10 +91,20 @@ namespace CarCareTracker.Controllers
         }
         public IActionResult ForgotPassword()
         {
+            var remoteAuthConfig = _config.GetOpenIDConfig();
+            if (remoteAuthConfig.DisableRegularLogin && !string.IsNullOrWhiteSpace(remoteAuthConfig.LogOutURL))
+            {
+                return RedirectToAction("Index");
+            }
             return View();
         }
         public IActionResult ResetPassword(string token = "", string email = "")
         {
+            var remoteAuthConfig = _config.GetOpenIDConfig();
+            if (remoteAuthConfig.DisableRegularLogin && !string.IsNullOrWhiteSpace(remoteAuthConfig.LogOutURL))
+            {
+                return RedirectToAction("Index");
+            }
             var viewModel = new LoginModel
             {
                 EmailAddress = string.IsNullOrWhiteSpace(email) ? string.Empty : email,


### PR DESCRIPTION
When OIDC-only login is enforced, prevent users from navigating to:

- /Login/ForgotPassword
- /Login/ResetPassword
- /Login/Registration