### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/scripts/verify-jquery-cve-2015-9251.sh
+++ b/scripts/verify-jquery-cve-2015-9251.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Regression guard for CVE-2015-9251 mitigation in vendored jQuery (ajaxConvert).
+# @see https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49
+set -euo pipefail
+root="$(cd "$(dirname "$0")/.." && pwd)"
+jquery="$root/wwwroot/lib/jquery/dist/jquery.js"
+if ! grep -q 's.crossDomain && current === "script"' "$jquery"; then
+  echo "verify-jquery-cve-2015-9251: expected gh-2432 / CVE-2015-9251 guard in ajaxConvert" >&2
+  exit 1
+fi
+echo "verify-jquery-cve-2015-9251: ok"

--- a/wwwroot/lib/jquery/dist/jquery.js
+++ b/wwwroot/lib/jquery/dist/jquery.js
@@ -9226,6 +9226,11 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 			// Convert response if prev dataType is non-auto and differs from current
 			} else if ( prev !== "*" && prev !== current ) {
 
+				// Mitigate possible XSS vulnerability (gh-2432)
+				if ( s.crossDomain && current === "script" ) {
+					continue;
+				}
+
 				// Seek a direct converter
 				conv = converters[ prev + " " + current ] || converters[ "* " + current ];
 


### PR DESCRIPTION
## Summary

This PR mitigates **CVE-2015-9251** (jQuery **gh-2432**) in the vendored copy of jQuery at **`wwwroot/lib/jquery/dist/jquery.js`**. The change mirrors the upstream **`ajaxConvert`** guard from [jquery/jquery@2546bb35](https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49).

## Changes

- In **`ajaxConvert`**, skip converter lookup when **`s.crossDomain && current === "script"`** (same logic as upstream: `continue` to the next `dataTypes` step).
- Add **`scripts/verify-jquery-cve-2015-9251.sh`**, a small regression check that asserts the mitigation string is present (no new dependencies).

## Impact

Aligns vendored jQuery with the upstream fix for cross-domain script conversion behavior tied to **CVE-2015-9251**, reducing XSS risk from the historical **`$.ajax`** code path addressed in gh-2432.

## References

- **CVE:** [CVE-2015-9251](https://nvd.nist.gov/vuln/detail/CVE-2015-9251)
- **Upstream fix:** [jquery/jquery@2546bb35](https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49) (Ajax: Mitigate possible XSS vulnerability; fixes gh-2432)

## Verification

**Before (reproduction):** At `main`, `wwwroot/lib/jquery/dist/jquery.js` had no `s.crossDomain && current === "script"` guard inside `ajaxConvert` before the “Seek a direct converter” block.

**After (fix):** The guard is present; regression script succeeds:

```bash
./scripts/verify-jquery-cve-2015-9251.sh
# verify-jquery-cve-2015-9251: ok
```

**Build:** `dotnet build` (SDK 10.0) succeeded in a container against this branch — **0 errors** (existing nullable-analysis warnings only; unchanged by this PR):

```bash
docker run --rm -v "$(pwd):/App" -w /App mcr.microsoft.com/dotnet/sdk:10.0 dotnet build -v minimal
```
