### PR TITLE
Make OIDC login flow respect the remember me switch

### DIFF
--- a/Controllers/LoginController.cs
+++ b/Controllers/LoginController.cs
@@ -112,7 +112,7 @@ namespace CarCareTracker.Controllers
             };
             return View(viewModel);
         }
-        public IActionResult GetRemoteLoginLink(string redirectURLBase64)
+        public IActionResult GetRemoteLoginLink(string redirectURLBase64, bool isPersistent)
         {
             var remoteAuthConfig = _config.GetOpenIDConfig();
             var generatedState = Guid.NewGuid().ToString().Substring(0, 8);
@@ -131,6 +131,9 @@ namespace CarCareTracker.Controllers
             {
                 Response.Cookies.Append("OIDC_REDIRECTURL", redirectURLBase64, new CookieOptions { Expires = new DateTimeOffset(DateTime.Now.AddMinutes(5)) });
             }
+
+            Response.Cookies.Append("OIDC_PERSISTENT", isPersistent.ToString().ToLower(), new CookieOptions { Expires = DateTimeOffset.Now.AddMinutes(5) });
+
             var remoteAuthURL = remoteAuthConfig.RemoteAuthURL;
             return Json(remoteAuthURL);
         }
@@ -255,10 +258,19 @@ namespace CarCareTracker.Controllers
                                 var userData = _loginLogic.ValidateOpenIDUser(new LoginModel() { EmailAddress = userEmailAddress });
                                 if (userData.Id != default)
                                 {
+                                    var persistentCookie = Request.Cookies["OIDC_PERSISTENT"];
+
+                                    bool isPersistent = false;
+                                    if (!string.IsNullOrWhiteSpace(persistentCookie))
+                                    {
+                                        bool.TryParse(persistentCookie, out isPersistent);
+                                        Response.Cookies.Delete("OIDC_PERSISTENT");
+                                    }
+
                                     AuthCookie authCookie = new AuthCookie
                                     {
                                         UserData = userData,
-                                        ExpiresOn = DateTime.Now.AddDays(1)
+                                        ExpiresOn = DateTime.Now.AddDays(isPersistent ? _config.GetAuthCookieLifeSpan() : 1)
                                     };
                                     var serializedCookie = JsonSerializer.Serialize(authCookie);
                                     var encryptedCookie = _dataProtector.Protect(serializedCookie);

--- a/wwwroot/js/login.js
+++ b/wwwroot/js/login.js
@@ -57,11 +57,12 @@ function performPasswordReset() {
 
 function remoteLogin() {
     let currentParams = new URLSearchParams(window.location.search);
+    let isPersistent = $("#inputPersistent").is(":checked");
     let redirectUrl = currentParams.get('redirectURLBase64');
     if (redirectUrl == null) {
         redirectUrl = '';
     }
-    $.get(`/Login/GetRemoteLoginLink?redirectURLBase64=${redirectUrl}`, { redirectURLBase64: redirectUrl }, function (data) {
+    $.get(`/Login/GetRemoteLoginLink?redirectURLBase64=${redirectUrl}`, { redirectURLBase64: redirectUrl, isPersistent: isPersistent }, function (data) {
         if (data) {
             window.location.href = data;
         }


### PR DESCRIPTION
As of right now, a successfull OIDC authentication results in a access token cookie with a hardcoded expiry of one day, not considering the remember me switch at all.

I have zero C# and DotNET experience so I might not have done a perfect job, but the general gist of it should be correct and it is indeed working as expected.