### PR TITLE
Add DELETE /api/vehicles/delete

### DIFF
--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -25,6 +25,9 @@ namespace CarCareTracker.Controllers
         private readonly IOdometerRecordDataAccess _odometerRecordDataAccess;
         private readonly ISupplyRecordDataAccess _supplyRecordDataAccess;
         private readonly IPlanRecordDataAccess _planRecordDataAccess;
+        private readonly IPlanRecordTemplateDataAccess _planRecordTemplateDataAccess;
+        private readonly IInspectionRecordDataAccess _inspectionRecordDataAccess;
+        private readonly IInspectionRecordTemplateDataAccess _inspectionRecordTemplateDataAccess;
         private readonly IEquipmentRecordDataAccess _equipmentRecordDataAccess;
         private readonly IUserAccessDataAccess _userAccessDataAccess;
         private readonly IUserRecordDataAccess _userRecordDataAccess;
@@ -55,6 +58,9 @@ namespace CarCareTracker.Controllers
             IOdometerRecordDataAccess odometerRecordDataAccess,
             ISupplyRecordDataAccess supplyRecordDataAccess,
             IPlanRecordDataAccess planRecordDataAccess,
+            IPlanRecordTemplateDataAccess planRecordTemplateDataAccess,
+            IInspectionRecordDataAccess inspectionRecordDataAccess,
+            IInspectionRecordTemplateDataAccess inspectionRecordTemplateDataAccess,
             IEquipmentRecordDataAccess equipmentRecordDataAccess,
             IUserAccessDataAccess userAccessDataAccess,
             IUserRecordDataAccess userRecordDataAccess,
@@ -80,6 +86,9 @@ namespace CarCareTracker.Controllers
             _odometerRecordDataAccess = odometerRecordDataAccess;
             _supplyRecordDataAccess = supplyRecordDataAccess;
             _planRecordDataAccess = planRecordDataAccess;
+            _planRecordTemplateDataAccess = planRecordTemplateDataAccess;
+            _inspectionRecordDataAccess = inspectionRecordDataAccess;
+            _inspectionRecordTemplateDataAccess = inspectionRecordTemplateDataAccess;
             _equipmentRecordDataAccess = equipmentRecordDataAccess;
             _userAccessDataAccess = userAccessDataAccess;
             _userRecordDataAccess = userRecordDataAccess;
@@ -411,6 +420,44 @@ namespace CarCareTracker.Controllers
                 Response.StatusCode = 500;
                 return Json(OperationResponse.Failed(ex.Message));
             }
+        }
+        [TypeFilter(typeof(APIKeyFilter), Arguments = new object[] { HouseholdPermission.Delete })]
+        [HttpDelete]
+        [Route("/api/vehicles/delete")]
+        public IActionResult DeleteVehicle(int vehicleId)
+        {
+            var existingVehicle = _dataAccess.GetVehicleById(vehicleId);
+            if (existingVehicle == null || existingVehicle.Id == default)
+            {
+                Response.StatusCode = 400;
+                return Json(OperationResponse.Failed("Invalid Vehicle Id"));
+            }
+            if (!_userLogic.UserCanEditVehicle(GetUserID(), vehicleId, HouseholdPermission.Delete))
+            {
+                Response.StatusCode = 401;
+                return Json(OperationResponse.Failed("Access Denied, you don't have access to this vehicle."));
+            }
+            var result = _gasRecordDataAccess.DeleteAllGasRecordsByVehicleId(vehicleId) &&
+                _serviceRecordDataAccess.DeleteAllServiceRecordsByVehicleId(vehicleId) &&
+                _collisionRecordDataAccess.DeleteAllCollisionRecordsByVehicleId(vehicleId) &&
+                _taxRecordDataAccess.DeleteAllTaxRecordsByVehicleId(vehicleId) &&
+                _noteDataAccess.DeleteAllNotesByVehicleId(vehicleId) &&
+                _reminderRecordDataAccess.DeleteAllReminderRecordsByVehicleId(vehicleId) &&
+                _upgradeRecordDataAccess.DeleteAllUpgradeRecordsByVehicleId(vehicleId) &&
+                _planRecordDataAccess.DeleteAllPlanRecordsByVehicleId(vehicleId) &&
+                _planRecordTemplateDataAccess.DeleteAllPlanRecordTemplatesByVehicleId(vehicleId) &&
+                _inspectionRecordDataAccess.DeleteAllInspectionRecordsByVehicleId(vehicleId) &&
+                _inspectionRecordTemplateDataAccess.DeleteAllInspectionReportTemplatesByVehicleId(vehicleId) &&
+                _equipmentRecordDataAccess.DeleteAllEquipmentRecordsByVehicleId(vehicleId) &&
+                _supplyRecordDataAccess.DeleteAllSupplyRecordsByVehicleId(vehicleId) &&
+                _odometerRecordDataAccess.DeleteAllOdometerRecordsByVehicleId(vehicleId) &&
+                _userLogic.DeleteAllAccessToVehicle(vehicleId) &&
+                _dataAccess.DeleteVehicle(vehicleId);
+            if (result)
+            {
+                _eventLogic.PublishEvent(GetUserID(), WebHookPayload.Generic($"Deleted Vehicle - Id: {vehicleId}", "vehicle.delete.api", User.Identity?.Name ?? string.Empty, vehicleId.ToString()));
+            }
+            return Json(OperationResponse.Conditional(result, "Vehicle Deleted"));
         }
         [HttpPost]
         [Route("/api/documents/upload")]

--- a/wwwroot/defaults/api.json
+++ b/wwwroot/defaults/api.json
@@ -75,7 +75,7 @@
             "description":"Updates a vehicle",
             "methodType":2,
             "queryParams":[
-               
+
             ],
             "hasBody":true,
             "bodyParamName":"input",
@@ -95,6 +95,20 @@
                   }
                ]
             }
+         },
+         {
+            "path":"/api/vehicles/delete",
+            "description":"Deletes a vehicle and all its associated records",
+            "methodType":3,
+            "queryParams":[
+               {
+                  "name":"vehicleId",
+                  "description":"Id of the vehicle",
+                  "required":true
+               }
+            ],
+            "hasBody":false,
+            "bodySample":null
          }
       ]
    },


### PR DESCRIPTION
Exposes vehicle deletion through the REST API, which was previously only possible through the web UI.

The endpoint mirrors the existing `VehicleController.DeleteVehicle` behavior, it cascades through all associated records (service, gas, repair, tax, odometer, reminders, upgrades, plans, plan templates, inspections, inspection templates, equipment, supplies, notes) before deleting the vehicle itself. Requires `Delete` permission via API key. Also adds the three missing data access interface injections (`IPlanRecordTemplateDataAccess`, `IInspectionRecordDataAccess`, `IInspectionRecordTemplateDataAccess`) to `APIController` that were needed to support the full cascade, and documents the new endpoint in `api.json`.