### PR TITLE
Add API CRUD for Inspection Record Templates

### DIFF
--- a/Controllers/API/InspectionController.cs
+++ b/Controllers/API/InspectionController.cs
@@ -99,7 +99,7 @@ namespace CarCareTracker.Controllers
                 var tagsFilter = parameters.Tags.Split(' ').Distinct();
                 templateResults.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
             }
-            var results = templateResults.Select(x => new InspectionRecordTemplateExportModel { VehicleId = x.VehicleId.ToString(), Id = x.Id.ToString(), Description = x.Description, Fields = ConvertToInspectionRecordTemplateFieldExportModels(x.Fields), Tags = string.Join(' ', x.Tags) });
+            var results = templateResults.Select(x => new InspectionRecordTemplateExportModel { VehicleId = x.VehicleId.ToString(), Id = x.Id.ToString(), Description = x.Description, Fields = ConvertToInspectionRecordTemplateFieldExportModels(x.Fields), Tags = string.Join(' ', x.Tags), ReminderRecordId = x.ReminderRecordId });
             if (_config.GetInvariantApi() || Request.Headers.ContainsKey("culture-invariant"))
             {
                 return Json(results, StaticHelper.GetInvariantOption());
@@ -129,7 +129,7 @@ namespace CarCareTracker.Controllers
                 var tagsFilter = parameters.Tags.Split(' ').Distinct();
                 templateResults.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
             }
-            var results = templateResults.Select(x => new InspectionRecordTemplateExportModel { VehicleId = x.VehicleId.ToString(), Id = x.Id.ToString(), Description = x.Description, Fields = ConvertToInspectionRecordTemplateFieldExportModels(x.Fields), Tags = string.Join(' ', x.Tags) });
+            var results = templateResults.Select(x => new InspectionRecordTemplateExportModel { VehicleId = x.VehicleId.ToString(), Id = x.Id.ToString(), Description = x.Description, Fields = ConvertToInspectionRecordTemplateFieldExportModels(x.Fields), Tags = string.Join(' ', x.Tags), ReminderRecordId = x.ReminderRecordId });
             if (_config.GetInvariantApi() || Request.Headers.ContainsKey("culture-invariant"))
             {
                 return Json(results, StaticHelper.GetInvariantOption());
@@ -178,7 +178,8 @@ namespace CarCareTracker.Controllers
                     VehicleId = vehicleId,
                     Description = input.Description,
                     Fields = convertedFields,
-                    Tags = string.IsNullOrWhiteSpace(input.Tags) ? new List<string>() : input.Tags.Split(' ').Distinct().ToList()
+                    Tags = string.IsNullOrWhiteSpace(input.Tags) ? new List<string>() : input.Tags.Split(' ').Distinct().ToList(),
+                    ReminderRecordId = input.ReminderRecordId ?? new List<int>()
                 };
                 _inspectionRecordTemplateDataAccess.SaveInspectionReportTemplateToVehicle(inspectionRecordTemplate);
                 return Json(OperationResponse.Succeed("Inspection Record Template Added", new { recordId = inspectionRecordTemplate.Id }));
@@ -228,6 +229,7 @@ namespace CarCareTracker.Controllers
                     existingRecord.Description = input.Description;
                     existingRecord.Fields = convertedFields;
                     existingRecord.Tags = string.IsNullOrWhiteSpace(input.Tags) ? new List<string>() : input.Tags.Split(' ').Distinct().ToList();
+                    existingRecord.ReminderRecordId = input.ReminderRecordId ?? new List<int>();
                     _inspectionRecordTemplateDataAccess.SaveInspectionReportTemplateToVehicle(existingRecord);
                 }
                 else

--- a/Controllers/API/InspectionController.cs
+++ b/Controllers/API/InspectionController.cs
@@ -1,0 +1,267 @@
+using CarCareTracker.Filter;
+using CarCareTracker.Helper;
+using CarCareTracker.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CarCareTracker.Controllers
+{
+    public partial class APIController
+    {
+        private List<InspectionRecordTemplateFieldExportModel> ConvertToInspectionRecordTemplateFieldExportModels(List<InspectionRecordTemplateField> input)
+        {
+            return input.Select(x => new InspectionRecordTemplateFieldExportModel
+            {
+                Description = x.Description,
+                FieldType = x.FieldType.ToString(),
+                Options = x.Options.Select(y => new InspectionRecordTemplateFieldOptionExportModel { Description = y.Description, IsFail = y.IsFail.ToString() }).ToList(),
+                HasNotes = x.HasNotes.ToString(),
+                Notes = x.Notes,
+                HasActionItem = x.HasActionItem.ToString(),
+                ActionItemType = x.ActionItemType.ToString(),
+                ActionItemDescription = x.ActionItemDescription,
+                ActionItemPriority = x.ActionItemPriority.ToString()
+            }).ToList();
+        }
+        private bool TryConvertInspectionRecordTemplateFields(List<InspectionRecordTemplateFieldExportModel> input, out List<InspectionRecordTemplateField> result, out string errorMessage)
+        {
+            result = new List<InspectionRecordTemplateField>();
+            errorMessage = string.Empty;
+            foreach (var field in input)
+            {
+                if (string.IsNullOrWhiteSpace(field.Description))
+                {
+                    errorMessage = "Input object invalid, Field Description cannot be empty.";
+                    return false;
+                }
+                if (!Enum.TryParse(field.FieldType, out InspectionFieldType parsedFieldType))
+                {
+                    errorMessage = $"Input object invalid, FieldType({string.Join(", ", Enum.GetNames(typeof(InspectionFieldType)))}) is invalid for field '{field.Description}'.";
+                    return false;
+                }
+                bool hasActionItem = !string.IsNullOrWhiteSpace(field.HasActionItem) && bool.Parse(field.HasActionItem);
+                ImportMode parsedActionItemType = ImportMode.ServiceRecord;
+                PlanPriority parsedActionItemPriority = PlanPriority.Normal;
+                if (hasActionItem)
+                {
+                    if (!Enum.TryParse(field.ActionItemType, out parsedActionItemType))
+                    {
+                        errorMessage = $"Input object invalid, ActionItemType is invalid for field '{field.Description}'.";
+                        return false;
+                    }
+                    if (!Enum.TryParse(field.ActionItemPriority, out parsedActionItemPriority))
+                    {
+                        errorMessage = $"Input object invalid, ActionItemPriority({string.Join(", ", Enum.GetNames(typeof(PlanPriority)))}) is invalid for field '{field.Description}'.";
+                        return false;
+                    }
+                }
+                result.Add(new InspectionRecordTemplateField
+                {
+                    Description = field.Description,
+                    FieldType = parsedFieldType,
+                    Options = (field.Options ?? new List<InspectionRecordTemplateFieldOptionExportModel>()).Select(x => new InspectionRecordTemplateFieldOption
+                    {
+                        Description = x.Description,
+                        IsFail = !string.IsNullOrWhiteSpace(x.IsFail) && bool.Parse(x.IsFail),
+                        IsSelected = false
+                    }).ToList(),
+                    HasNotes = !string.IsNullOrWhiteSpace(field.HasNotes) && bool.Parse(field.HasNotes),
+                    Notes = field.Notes ?? string.Empty,
+                    HasActionItem = hasActionItem,
+                    ActionItemType = parsedActionItemType,
+                    ActionItemDescription = field.ActionItemDescription ?? string.Empty,
+                    ActionItemPriority = parsedActionItemPriority
+                });
+            }
+            return true;
+        }
+        [HttpGet]
+        [Route("/api/vehicle/inspection/templates/all")]
+        public IActionResult AllInspectionRecordTemplates(MethodParameter parameters)
+        {
+            List<int> vehicleIds = new List<int>();
+            var vehicles = _dataAccess.GetVehicles();
+            if (!User.IsInRole(nameof(UserData.IsRootUser)))
+            {
+                vehicles = _userLogic.FilterUserVehicles(vehicles, GetUserID());
+            }
+            vehicleIds.AddRange(vehicles.Select(x => x.Id));
+            List<InspectionRecordInput> templateResults = new List<InspectionRecordInput>();
+            foreach (int vehicleId in vehicleIds)
+            {
+                templateResults.AddRange(_inspectionRecordTemplateDataAccess.GetInspectionRecordTemplatesByVehicleId(vehicleId));
+            }
+            if (parameters.Id != default)
+            {
+                templateResults.RemoveAll(x => x.Id != parameters.Id);
+            }
+            if (!string.IsNullOrWhiteSpace(parameters.Tags))
+            {
+                var tagsFilter = parameters.Tags.Split(' ').Distinct();
+                templateResults.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+            }
+            var results = templateResults.Select(x => new InspectionRecordTemplateExportModel { VehicleId = x.VehicleId.ToString(), Id = x.Id.ToString(), Description = x.Description, Fields = ConvertToInspectionRecordTemplateFieldExportModels(x.Fields), Tags = string.Join(' ', x.Tags) });
+            if (_config.GetInvariantApi() || Request.Headers.ContainsKey("culture-invariant"))
+            {
+                return Json(results, StaticHelper.GetInvariantOption());
+            }
+            else
+            {
+                return Json(results);
+            }
+        }
+        [TypeFilter(typeof(CollaboratorFilter))]
+        [HttpGet]
+        [Route("/api/vehicle/inspection/templates")]
+        public IActionResult InspectionRecordTemplates(int vehicleId, MethodParameter parameters)
+        {
+            if (vehicleId == default)
+            {
+                Response.StatusCode = 400;
+                return Json(OperationResponse.Failed("Must provide a valid vehicle id"));
+            }
+            var templateResults = _inspectionRecordTemplateDataAccess.GetInspectionRecordTemplatesByVehicleId(vehicleId);
+            if (parameters.Id != default)
+            {
+                templateResults.RemoveAll(x => x.Id != parameters.Id);
+            }
+            if (!string.IsNullOrWhiteSpace(parameters.Tags))
+            {
+                var tagsFilter = parameters.Tags.Split(' ').Distinct();
+                templateResults.RemoveAll(x => !x.Tags.Any(y => tagsFilter.Contains(y)));
+            }
+            var results = templateResults.Select(x => new InspectionRecordTemplateExportModel { VehicleId = x.VehicleId.ToString(), Id = x.Id.ToString(), Description = x.Description, Fields = ConvertToInspectionRecordTemplateFieldExportModels(x.Fields), Tags = string.Join(' ', x.Tags) });
+            if (_config.GetInvariantApi() || Request.Headers.ContainsKey("culture-invariant"))
+            {
+                return Json(results, StaticHelper.GetInvariantOption());
+            }
+            else
+            {
+                return Json(results);
+            }
+        }
+        [TypeFilter(typeof(QueryParamFilter), Arguments = new object[] { new string[] { "vehicleId" } })]
+        [TypeFilter(typeof(APIKeyFilter), Arguments = new object[] { HouseholdPermission.Edit })]
+        [TypeFilter(typeof(CollaboratorFilter), Arguments = new object[] { false, true, HouseholdPermission.Edit })]
+        [HttpPost]
+        [Route("/api/vehicle/inspection/templates/add")]
+        [Consumes("application/json")]
+        public IActionResult AddInspectionRecordTemplateJson(int vehicleId, [FromBody] InspectionRecordTemplateExportModel input) => AddInspectionRecordTemplate(vehicleId, input);
+        [TypeFilter(typeof(APIKeyFilter), Arguments = new object[] { HouseholdPermission.Edit })]
+        [TypeFilter(typeof(CollaboratorFilter), Arguments = new object[] { false, true, HouseholdPermission.Edit })]
+        [HttpPost]
+        [Route("/api/vehicle/inspection/templates/add")]
+        public IActionResult AddInspectionRecordTemplate(int vehicleId, InspectionRecordTemplateExportModel input)
+        {
+            if (vehicleId == default)
+            {
+                Response.StatusCode = 400;
+                return Json(OperationResponse.Failed("Must provide a valid vehicle id"));
+            }
+            if (string.IsNullOrWhiteSpace(input.Description))
+            {
+                Response.StatusCode = 400;
+                return Json(OperationResponse.Failed("Input object invalid, Description cannot be empty."));
+            }
+            if (input.Fields == null)
+            {
+                input.Fields = new List<InspectionRecordTemplateFieldExportModel>();
+            }
+            if (!TryConvertInspectionRecordTemplateFields(input.Fields, out var convertedFields, out var fieldErrorMessage))
+            {
+                Response.StatusCode = 400;
+                return Json(OperationResponse.Failed(fieldErrorMessage));
+            }
+            try
+            {
+                var inspectionRecordTemplate = new InspectionRecordInput()
+                {
+                    VehicleId = vehicleId,
+                    Description = input.Description,
+                    Fields = convertedFields,
+                    Tags = string.IsNullOrWhiteSpace(input.Tags) ? new List<string>() : input.Tags.Split(' ').Distinct().ToList()
+                };
+                _inspectionRecordTemplateDataAccess.SaveInspectionReportTemplateToVehicle(inspectionRecordTemplate);
+                return Json(OperationResponse.Succeed("Inspection Record Template Added", new { recordId = inspectionRecordTemplate.Id }));
+            }
+            catch (Exception ex)
+            {
+                Response.StatusCode = 500;
+                return Json(OperationResponse.Failed(ex.Message));
+            }
+        }
+        [TypeFilter(typeof(APIKeyFilter), Arguments = new object[] { HouseholdPermission.Edit })]
+        [HttpPut]
+        [Route("/api/vehicle/inspection/templates/update")]
+        [Consumes("application/json")]
+        public IActionResult UpdateInspectionRecordTemplateJson([FromBody] InspectionRecordTemplateExportModel input) => UpdateInspectionRecordTemplate(input);
+        [TypeFilter(typeof(APIKeyFilter), Arguments = new object[] { HouseholdPermission.Edit })]
+        [HttpPut]
+        [Route("/api/vehicle/inspection/templates/update")]
+        public IActionResult UpdateInspectionRecordTemplate(InspectionRecordTemplateExportModel input)
+        {
+            if (string.IsNullOrWhiteSpace(input.Id) ||
+                string.IsNullOrWhiteSpace(input.Description))
+            {
+                Response.StatusCode = 400;
+                return Json(OperationResponse.Failed("Input object invalid, Id and Description cannot be empty."));
+            }
+            if (input.Fields == null)
+            {
+                input.Fields = new List<InspectionRecordTemplateFieldExportModel>();
+            }
+            if (!TryConvertInspectionRecordTemplateFields(input.Fields, out var convertedFields, out var fieldErrorMessage))
+            {
+                Response.StatusCode = 400;
+                return Json(OperationResponse.Failed(fieldErrorMessage));
+            }
+            try
+            {
+                var existingRecord = _inspectionRecordTemplateDataAccess.GetInspectionRecordTemplateById(int.Parse(input.Id));
+                if (existingRecord != null && existingRecord.Id == int.Parse(input.Id))
+                {
+                    //check if user has access to the vehicleId
+                    if (!_userLogic.UserCanEditVehicle(GetUserID(), existingRecord.VehicleId, HouseholdPermission.Edit))
+                    {
+                        Response.StatusCode = 401;
+                        return Json(OperationResponse.Failed("Access Denied, you don't have access to this vehicle."));
+                    }
+                    existingRecord.Description = input.Description;
+                    existingRecord.Fields = convertedFields;
+                    existingRecord.Tags = string.IsNullOrWhiteSpace(input.Tags) ? new List<string>() : input.Tags.Split(' ').Distinct().ToList();
+                    _inspectionRecordTemplateDataAccess.SaveInspectionReportTemplateToVehicle(existingRecord);
+                }
+                else
+                {
+                    Response.StatusCode = 400;
+                    return Json(OperationResponse.Failed("Invalid Record Id"));
+                }
+                return Json(OperationResponse.Succeed("Inspection Record Template Updated"));
+            }
+            catch (Exception ex)
+            {
+                Response.StatusCode = 500;
+                return Json(OperationResponse.Failed(ex.Message));
+            }
+        }
+        [TypeFilter(typeof(APIKeyFilter), Arguments = new object[] { HouseholdPermission.Delete })]
+        [HttpDelete]
+        [Route("/api/vehicle/inspection/templates/delete")]
+        public IActionResult DeleteInspectionRecordTemplate(int id)
+        {
+            var existingRecord = _inspectionRecordTemplateDataAccess.GetInspectionRecordTemplateById(id);
+            if (existingRecord == null || existingRecord.Id == default)
+            {
+                Response.StatusCode = 400;
+                return Json(OperationResponse.Failed("Invalid Record Id"));
+            }
+            //security check.
+            if (!_userLogic.UserCanEditVehicle(GetUserID(), existingRecord.VehicleId, HouseholdPermission.Delete))
+            {
+                Response.StatusCode = 401;
+                return Json(OperationResponse.Failed("Access Denied, you don't have access to this vehicle."));
+            }
+            var result = _inspectionRecordTemplateDataAccess.DeleteInspectionRecordTemplateById(existingRecord.Id);
+            return Json(OperationResponse.Conditional(result, "Inspection Record Template Deleted"));
+        }
+    }
+}

--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -25,6 +25,7 @@ namespace CarCareTracker.Controllers
         private readonly IOdometerRecordDataAccess _odometerRecordDataAccess;
         private readonly ISupplyRecordDataAccess _supplyRecordDataAccess;
         private readonly IPlanRecordDataAccess _planRecordDataAccess;
+        private readonly IInspectionRecordTemplateDataAccess _inspectionRecordTemplateDataAccess;
         private readonly IEquipmentRecordDataAccess _equipmentRecordDataAccess;
         private readonly IUserAccessDataAccess _userAccessDataAccess;
         private readonly IUserRecordDataAccess _userRecordDataAccess;
@@ -56,6 +57,7 @@ namespace CarCareTracker.Controllers
             IOdometerRecordDataAccess odometerRecordDataAccess,
             ISupplyRecordDataAccess supplyRecordDataAccess,
             IPlanRecordDataAccess planRecordDataAccess,
+            IInspectionRecordTemplateDataAccess inspectionRecordTemplateDataAccess,
             IEquipmentRecordDataAccess equipmentRecordDataAccess,
             IUserAccessDataAccess userAccessDataAccess,
             IUserRecordDataAccess userRecordDataAccess,
@@ -82,6 +84,7 @@ namespace CarCareTracker.Controllers
             _odometerRecordDataAccess = odometerRecordDataAccess;
             _supplyRecordDataAccess = supplyRecordDataAccess;
             _planRecordDataAccess = planRecordDataAccess;
+            _inspectionRecordTemplateDataAccess = inspectionRecordTemplateDataAccess;
             _equipmentRecordDataAccess = equipmentRecordDataAccess;
             _userAccessDataAccess = userAccessDataAccess;
             _userRecordDataAccess = userRecordDataAccess;

--- a/Models/Shared/ImportModel.cs
+++ b/Models/Shared/ImportModel.cs
@@ -244,6 +244,36 @@ namespace CarCareTracker.Models
         public List<ExtraField> ExtraFields { get; set; } = new List<ExtraField>();
         public List<UploadedFiles> Files { get; set; } = new List<UploadedFiles>();
     }
+    public class InspectionRecordTemplateExportModel
+    {
+        [JsonConverter(typeof(FromIntOptional))]
+        public string VehicleId { get; set; } = string.Empty;
+        [JsonConverter(typeof(FromIntOptional))]
+        public string Id { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public List<InspectionRecordTemplateFieldExportModel> Fields { get; set; } = new List<InspectionRecordTemplateFieldExportModel>();
+        public string Tags { get; set; } = string.Empty;
+    }
+    public class InspectionRecordTemplateFieldExportModel
+    {
+        public string Description { get; set; } = string.Empty;
+        public string FieldType { get; set; } = "Text";
+        public List<InspectionRecordTemplateFieldOptionExportModel> Options { get; set; } = new List<InspectionRecordTemplateFieldOptionExportModel>();
+        [JsonConverter(typeof(FromBoolOptional))]
+        public string HasNotes { get; set; } = string.Empty;
+        public string Notes { get; set; } = string.Empty;
+        [JsonConverter(typeof(FromBoolOptional))]
+        public string HasActionItem { get; set; } = string.Empty;
+        public string ActionItemType { get; set; } = "ServiceRecord";
+        public string ActionItemDescription { get; set; } = string.Empty;
+        public string ActionItemPriority { get; set; } = "Normal";
+    }
+    public class InspectionRecordTemplateFieldOptionExportModel
+    {
+        public string Description { get; set; } = string.Empty;
+        [JsonConverter(typeof(FromBoolOptional))]
+        public string IsFail { get; set; } = string.Empty;
+    }
     public class UserExportModel
     {
         public string Username { get; set; } = string.Empty;

--- a/Models/Shared/ImportModel.cs
+++ b/Models/Shared/ImportModel.cs
@@ -253,6 +253,7 @@ namespace CarCareTracker.Models
         public string Description { get; set; } = string.Empty;
         public List<InspectionRecordTemplateFieldExportModel> Fields { get; set; } = new List<InspectionRecordTemplateFieldExportModel>();
         public string Tags { get; set; } = string.Empty;
+        public List<int> ReminderRecordId { get; set; } = new List<int>();
     }
     public class InspectionRecordTemplateFieldExportModel
     {

--- a/wwwroot/defaults/api.json
+++ b/wwwroot/defaults/api.json
@@ -1504,6 +1504,128 @@
       ]
    },
    {
+      "categoryName":"Inspection Record Templates",
+      "methods":[
+         {
+            "path":"/api/vehicle/inspection/templates/all",
+            "description":"Gets Inspection Record Templates for all vehicles in user's garage",
+            "methodType":0,
+            "queryParams":[
+               {
+                  "name":"id",
+                  "description":"Id of the specific record",
+                  "required":false
+               },
+               {
+                  "name":"tags",
+                  "description":"Tags separated by space",
+                  "required":false
+               }
+            ],
+            "hasBody":false,
+            "bodySample":null
+         },
+         {
+            "path":"/api/vehicle/inspection/templates",
+            "description":"Gets Inspection Record Templates for a vehicle in user's garage",
+            "methodType":0,
+            "queryParams":[
+               {
+                  "name":"vehicleId",
+                  "description":"Id of the vehicle",
+                  "required":true
+               },
+               {
+                  "name":"id",
+                  "description":"Id of the specific record",
+                  "required":false
+               },
+               {
+                  "name":"tags",
+                  "description":"Tags separated by space",
+                  "required":false
+               }
+            ],
+            "hasBody":false,
+            "bodySample":null
+         },
+         {
+            "path":"/api/vehicle/inspection/templates/add",
+            "description":"Adds an Inspection Record Template for a vehicle",
+            "bodyParamName":"input",
+            "methodType":1,
+            "queryParams":[
+               {
+                  "name":"vehicleId",
+                  "description":"Id of the vehicle",
+                  "required":true
+               }
+            ],
+            "hasBody":true,
+            "bodySample":[{
+               "description":"Pre-Trip Inspection",
+               "fields":[
+                  {
+                     "description":"Tire Tread",
+                     "fieldType":"Text",
+                     "hasNotes":false,
+                     "hasActionItem":false
+                  },
+                  {
+                     "description":"Brake Pads",
+                     "fieldType":"Radio",
+                     "options":[
+                        {"description":"Pass","isFail":false},
+                        {"description":"Fail","isFail":true}
+                     ],
+                     "hasNotes":true,
+                     "hasActionItem":true,
+                     "actionItemType":"RepairRecord",
+                     "actionItemDescription":"Replace brake pads",
+                     "actionItemPriority":"Normal"
+                  }
+               ],
+               "tags":"safety"
+            }]
+         },
+         {
+            "path":"/api/vehicle/inspection/templates/update",
+            "description":"Updates an Inspection Record Template for a vehicle",
+            "bodyParamName":"input",
+            "methodType":2,
+            "queryParams":[],
+            "hasBody":true,
+            "bodySample":[{
+               "id":1,
+               "description":"Pre-Trip Inspection",
+               "fields":[
+                  {
+                     "description":"Tire Tread",
+                     "fieldType":"Text",
+                     "hasNotes":false,
+                     "hasActionItem":false
+                  }
+               ],
+               "tags":"safety"
+            }]
+         },
+         {
+            "path":"/api/vehicle/inspection/templates/delete",
+            "description":"Deletes an Inspection Record Template",
+            "methodType":3,
+            "queryParams":[
+               {
+                  "name":"id",
+                  "description":"Id of the Inspection Record Template",
+                  "required":true
+               }
+            ],
+            "hasBody":false,
+            "bodySample":null
+         }
+      ]
+   },
+   {
       "categoryName":"Equipment Records",
       "methods":[
          {

--- a/wwwroot/defaults/api.json
+++ b/wwwroot/defaults/api.json
@@ -1585,7 +1585,8 @@
                      "actionItemPriority":"Normal"
                   }
                ],
-               "tags":"safety"
+               "tags":"safety",
+               "reminderRecordId":[1]
             }]
          },
          {
@@ -1606,7 +1607,8 @@
                      "hasActionItem":false
                   }
                ],
-               "tags":"safety"
+               "tags":"safety",
+               "reminderRecordId":[1]
             }]
          },
          {


### PR DESCRIPTION
Closes #1435

## Summary
- Every other record type (Reminders, Plans, Repairs, Services, Supplies, Taxes, Upgrades, Equipment, Notes, Odometer, Gas) already has a full `/api/vehicle/...` controller. Inspection Record Templates were the one exception — reachable only through the cookie-authenticated UI controller, no `[APIKeyFilter]`, no `/api/` route.
- Adds `Controllers/API/InspectionController.cs` with List (per-vehicle + all-vehicles), Add, Update, Delete — following the same JSON+form dual-route convention, `APIKeyFilter`/`CollaboratorFilter` gating, and ownership checks as the existing controllers.
- Adds `InspectionRecordTemplateExportModel` (+ nested field/option export models) to `Models/Shared/ImportModel.cs`, with enums represented as strings and validated via `Enum.TryParse`, matching every other export model in the API rather than binding JSON directly to the native enum-typed `InspectionRecordTemplateField`.
- Exposes `ReminderRecordId` on the template so it can be linked to existing recurring reminders via the API (previously only settable through the UI's template edit modal).
- Documents the new endpoints in `wwwroot/defaults/api.json` alongside every other category.

## Test plan
- `docker build` against this branch — compiles clean, no new warnings introduced.
- Ran the built image locally and exercised the full CRUD surface with curl: list (per-vehicle + all-vehicles), id/tag filtering, add, update, delete, and validation error paths (missing description, invalid enum values) — all return clean 400s with actionable messages instead of crashing.
- Confirmed a template created via the API renders correctly in the existing UI's template edit modal (no round-trip issues).
- Confirmed linking a reminder via the new `reminderRecordId` field persists and reads back correctly.

## Note (found while testing, not fixed here)
While testing the reminder link, I noticed `VehicleController.GetEditInspectionRecordTemplatePartialView` silently drops any linked `ReminderRecordId` whose reminder isn't `IsRecurring` — just from *opening* the template's edit modal (the returned view model has the link already cleared), so opening-then-saving a template whose linked reminder hasn't been flipped to recurring yet will silently drop the link with no warning. This is pre-existing behavior, unrelated to this PR's diff, and I didn't want to bundle a fix into a PR meant to just close the API gap. A couple of directions if it's worth addressing, though I'm not sure which is preferable:
- Only filter the reminder *selector dropdown* by `IsRecurring`, but leave already-linked (even non-recurring) reminders in the stored list untouched until the user explicitly changes the selection.
- Show a warning/confirmation when a save would drop a link, rather than doing it silently.

Happy to open a separate issue for this if that's more useful than a note here.
